### PR TITLE
ConfigExtensions: Tolerate implementation and breaking API changes in BDN

### DIFF
--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ConfigExtensions.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ConfigExtensions.cs
@@ -89,7 +89,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceExporters(this ManualConfig config, params IExporter[] newExporters)
         {
-            ClearList(config.GetExporters());
+            ClearEnumerable(config.GetExporters());
             return config.AddExporter(newExporters);
         }
 
@@ -102,7 +102,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceLoggers(this ManualConfig config, params ILogger[] newLoggers)
         {
-            ClearList(config.GetLoggers());
+            ClearEnumerable(config.GetLoggers());
             return config.AddLogger(newLoggers);
         }
 
@@ -115,7 +115,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceDiagnosers(this ManualConfig config, params IDiagnoser[] newDiagnosers)
         {
-            ClearList(config.GetDiagnosers());
+            ClearEnumerable(config.GetDiagnosers());
             return config.AddDiagnoser(newDiagnosers);
         }
 
@@ -128,7 +128,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceAnalysers(this ManualConfig config, params IAnalyser[] newAnalysers)
         {
-            ClearList(config.GetAnalysers());
+            ClearEnumerable(config.GetAnalysers());
             return config.AddAnalyser(newAnalysers);
         }
 
@@ -141,7 +141,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceJobs(this ManualConfig config, params Job[] newJobs)
         {
-            ClearList(config.GetJobs());
+            ClearEnumerable(config.GetJobs());
             return config.AddJob(newJobs);
         }
 
@@ -154,7 +154,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceValidators(this ManualConfig config, params IValidator[] newValidators)
         {
-            ClearList(config.GetValidators());
+            ClearEnumerable(config.GetValidators());
             return config.AddValidator(newValidators);
         }
 
@@ -168,7 +168,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         public static ManualConfig ReplaceHardwareCounters(this ManualConfig config,
                                                            params HardwareCounter[] newHardwareCounters)
         {
-            ClearHashSet(config.GetHardwareCounters());
+            ClearEnumerable(config.GetHardwareCounters());
             return config.AddHardwareCounters(newHardwareCounters);
         }
 
@@ -182,7 +182,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         /// <returns>The existing <see cref="ManualConfig"/> with changes applied.</returns>
         public static ManualConfig ReplaceFilters(this ManualConfig config, params IFilter[] newFilters)
         {
-            ClearList(config.GetFilters());
+            ClearEnumerable(config.GetFilters());
             return config.AddFilter(newFilters);
         }
 
@@ -196,7 +196,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
         public static ManualConfig ReplaceLogicalGroupRules(this ManualConfig config,
                                                             params BenchmarkLogicalGroupRule[] newLogicalGroupRules)
         {
-            ClearHashSet(config.GetLogicalGroupRules());
+            ClearEnumerable(config.GetLogicalGroupRules());
             return config.AddLogicalGroupRules(newLogicalGroupRules);
         }
 
@@ -213,14 +213,15 @@ namespace Mawosoft.Extensions.BenchmarkDotNet
             ?? throw new InvalidOperationException($"Failed to get List<{typeof(T).Name}>.");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static HashSet<T> AsHashSet<T>(IEnumerable<T> enumerable)
-            => enumerable as HashSet<T>
-            ?? throw new InvalidOperationException($"Failed to get HashSet<{typeof(T).Name}>.");
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ClearList<T>(IEnumerable<T> enumerable) => AsList(enumerable).Clear();
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ClearHashSet<T>(IEnumerable<T> enumerable) => AsHashSet(enumerable).Clear();
+        private static void ClearEnumerable<T>(IEnumerable<T> enumerable)
+        {
+            if (enumerable is List<T> list)
+                list.Clear();
+            else if (enumerable is HashSet<T> set)
+                set.Clear();
+            else
+                throw new InvalidOperationException(
+                    $"Failed to get List<{typeof(T).Name}> or HashSet<{typeof(T).Name}>.");
+        }
     }
 }

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Columns;
+using Xunit;
+using Xunit.Abstractions;
+
+using static Mawosoft.Extensions.BenchmarkDotNet.ColumnCategoryExtensions;
+
+namespace Mawosoft.Extensions.BenchmarkDotNet.Tests
+{
+    public class ColumnCategoryExtensionsTests
+    {
+        [Fact]
+        public void ToExtended_ExistingCategoriesMatch()
+        {
+            string[] categoryNamesArray = Enum.GetNames(typeof(ColumnCategory));
+            string[] extendedNamesArray = Enum.GetNames(typeof(ExtendedColumnCategory));
+            HashSet<string> categoryNames = new(categoryNamesArray);
+            HashSet<string> extendedNames = new(extendedNamesArray);
+            Assert.Equal(categoryNamesArray.Length, categoryNames.Count);
+            Assert.Equal(extendedNamesArray.Length, extendedNames.Count);
+            Assert.ProperSuperset(categoryNames, extendedNames);
+            foreach (string cname in categoryNames)
+            {
+                Assert.Equal(
+                    (ExtendedColumnCategory)Enum.Parse(typeof(ExtendedColumnCategory), cname),
+                    ColumnCategoryExtensions.ToExtended(
+                        (ColumnCategory)Enum.Parse(typeof(ColumnCategory), cname)));
+            }
+        }
+
+        [Fact]
+        public void ToExtended_NonExistingCategories_Unknown()
+        {
+            Assert.Equal(
+                ExtendedColumnCategory.Unknown,
+                ColumnCategoryExtensions.ToExtended(ColumnCategory.Metric + 1));
+        }
+
+        private class GetExtendedColumnCategory_TheoryData : TheoryData<IColumn, ExtendedColumnCategory>
+        {
+            // We get all existing IColumn classes via reflection and handle them by name
+            // to discover any new additions not covered by test.
+            public GetExtendedColumnCategory_TheoryData()
+            {
+                Func<Type, bool> predicate = t => t.IsClass && !t.IsAbstract && typeof(IColumn).IsAssignableFrom(t);
+
+                IEnumerable<Type> columnTypes =
+                    typeof(IColumn).Assembly.GetTypes().Where(predicate)
+                    .Concat(typeof(ColumnCategoryExtensions).Assembly.GetTypes().Where(predicate)
+                    .Distinct());
+
+                List<string> unexpectedTypes = new();
+
+                foreach (Type type in columnTypes)
+                {
+                    switch (type.Name)
+                    {
+                        // BenchmarkDotNet 0.13.1
+                        case "BaselineColumn":
+                            Add(new BaselineColumn(), ExtendedColumnCategory.Meta);
+                            break;
+                        case "BaselineRatioColumn":
+                            Add(BaselineRatioColumn.RatioMean, ExtendedColumnCategory.Baseline);
+                            break;
+                        case "BaselineScaledColumn":
+#pragma warning disable CS0618 // Type or member is obsolete
+                            Add(BaselineScaledColumn.Scaled, ExtendedColumnCategory.Baseline);
+#pragma warning restore CS0618 // Type or member is obsolete
+                            break;
+                        case "CategoriesColumn":
+                            Add(new CategoriesColumn(), ExtendedColumnCategory.Category);
+                            break;
+                        case "JobCharacteristicColumn":
+                            Add(JobCharacteristicColumn.AllColumns[0], ExtendedColumnCategory.Job);
+                            break;
+                        case "LogicalGroupColumn":
+                            Add(new LogicalGroupColumn(), ExtendedColumnCategory.Meta);
+                            break;
+                        case "MetricColumn":
+                            Add(new MetricColumn(null), ExtendedColumnCategory.Metric);
+                            break;
+                        case "ParamColumn":
+                            Add(new ParamColumn("head"), ExtendedColumnCategory.Params);
+                            break;
+                        case "RankColumn":
+                            Add(RankColumn.Arabic, ExtendedColumnCategory.Custom);
+                            break;
+                        case "StatisticalTestColumn":
+                            Add(new StatisticalTestColumn(Perfolizer.Mathematics.SignificanceTesting.StatisticalTestKind.Welch, Perfolizer.Mathematics.Thresholds.Threshold.Create(Perfolizer.Mathematics.Thresholds.ThresholdUnit.Ratio, 0), true), ExtendedColumnCategory.Baseline);
+                            break;
+                        case "StatisticColumn":
+                            Add(StatisticColumn.Mean, ExtendedColumnCategory.Statistics);
+                            break;
+                        case "TagColumn":
+                            Add(new TagColumn("tag", p => "tag"), ExtendedColumnCategory.Custom);
+                            break;
+                        case "TargetMethodColumn":
+                            Add(TargetMethodColumn.Namespace, ExtendedColumnCategory.TargetMethod);
+                            Add(TargetMethodColumn.Type, ExtendedColumnCategory.TargetMethod);
+                            Add(TargetMethodColumn.Method, ExtendedColumnCategory.TargetMethod);
+                            break;
+                        // BenchmarkDotNet 0.13.1.x-nightly
+                        case "BaselineAllocationRatioColumn":
+                            IColumn barc = (Activator.CreateInstance(type) as IColumn)!;
+                            Assert.NotNull(barc);
+                            Add(barc, ExtendedColumnCategory.Metric);
+                            break;
+                        // Mawosoft.Extensions.BenchmarkDotNet
+                        case "CombinedParamsColumn":
+                            Add(new CombinedParamsColumn(), ExtendedColumnCategory.Params);
+                            break;
+                        case "JobCharacteristicColumnWithLegend":
+                            Add(new JobCharacteristicColumnWithLegend(JobCharacteristicColumn.AllColumns[0], "legend"), ExtendedColumnCategory.Job);
+                            break;
+                        case "RecyclableParamColumn":
+                            Add(new RecyclableParamColumn(1, "param", false), ExtendedColumnCategory.Params);
+                            break;
+                        default:
+                            unexpectedTypes.Add(type.Name);
+                            break;
+                    }
+                }
+
+                Assert.Empty(unexpectedTypes);
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(GetExtendedColumnCategory_TheoryData))]
+        internal void GetExtendedColumnCategory_Succeeds(IColumn column, ExtendedColumnCategory extendedColumnCategory)
+        {
+            Assert.Equal(extendedColumnCategory, ColumnCategoryExtensions.GetExtendedColumnCategory(column));
+        }
+
+        private class GetExtendedColumnCategories_TheoryData : TheoryData<IColumnProvider, IEnumerable<ExtendedColumnCategory>>
+        {
+            // We get all existing IColumnProvider classes via reflection and handle them by name
+            // to discover any new additions not covered by test.
+            public GetExtendedColumnCategories_TheoryData()
+            {
+                Func<Type, bool> predicate = t => t.IsClass && !t.IsAbstract && typeof(IColumnProvider).IsAssignableFrom(t);
+
+                IEnumerable<Type> providerTypes =
+                    typeof(IColumn).Assembly.GetTypes().Where(predicate)
+                    .Concat(typeof(ColumnCategoryExtensions).Assembly.GetTypes().Where(predicate)
+                    .Distinct());
+
+                List<string> unexpectedTypes = new();
+
+                foreach (Type type in providerTypes)
+                {
+                    switch (type.Name)
+                    {
+                        // BenchmarkDotNet
+                        case "CompositeColumnProvider":
+                            Add(new CompositeColumnProvider(
+                                    DefaultColumnProviders.Descriptor, DefaultColumnProviders.Job),
+                                new[] { ExtendedColumnCategory.TargetMethod, ExtendedColumnCategory.Job });
+                            Add(new CompositeColumnProvider(
+                                    new JobColumnSelectionProvider("-all +job", true), new RecyclableParamsColumnProvider()),
+                                new[] { ExtendedColumnCategory.Job, ExtendedColumnCategory.Params });
+                            break;
+                        case "EmptyColumnProvider":
+                            Add(EmptyColumnProvider.Instance, Array.Empty<ExtendedColumnCategory>());
+                            break;
+                        case "SimpleColumnProvider":
+                            Add(new SimpleColumnProvider(
+                                    StatisticColumn.Mean, StatisticColumn.Error, TargetMethodColumn.Method),
+                                new[] { ExtendedColumnCategory.Statistics, ExtendedColumnCategory.TargetMethod });
+                            Add(new SimpleColumnProvider(new CategoriesColumn()),
+                                new[] { ExtendedColumnCategory.Category });
+                            break;
+                        case "DescriptorColumnProvider":
+                            Add(DefaultColumnProviders.Descriptor, new[] { ExtendedColumnCategory.TargetMethod });
+                            break;
+                        case "JobColumnProvider":
+                            Add(DefaultColumnProviders.Job, new[] { ExtendedColumnCategory.Job });
+                            break;
+                        case "StatisticsColumnProvider":
+                            Add(DefaultColumnProviders.Statistics, new[] { ExtendedColumnCategory.Statistics });
+                            break;
+                        case "ParamsColumnProvider":
+                            Add(DefaultColumnProviders.Params, new[] { ExtendedColumnCategory.Params });
+                            break;
+                        case "MetricsColumnProvider":
+                            Add(DefaultColumnProviders.Metrics, new[] { ExtendedColumnCategory.Metric });
+                            break;
+                        // Mawosoft.Extensions.BenchmarkDotNet
+                        case "JobColumnSelectionProvider":
+                            Add(new JobColumnSelectionProvider("+all", true), new[] { ExtendedColumnCategory.Job });
+                            break;
+                        case "RecyclableParamsColumnProvider":
+                            Add(new RecyclableParamsColumnProvider(), new[] { ExtendedColumnCategory.Params });
+                            break;
+                        default:
+                            unexpectedTypes.Add(type.Name);
+                            break;
+                    }
+                }
+
+                Assert.Empty(unexpectedTypes);
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(GetExtendedColumnCategories_TheoryData))]
+        internal void GetExtendedColumnCategories_Succeeds(IColumnProvider provider, IEnumerable<ExtendedColumnCategory> extendedColumnCategories)
+        {
+            Assert.Equal(
+                new HashSet<ExtendedColumnCategory>(extendedColumnCategories),
+                new HashSet<ExtendedColumnCategory>(ColumnCategoryExtensions.GetExtendedColumnCategories(provider)));
+        }
+
+        // For ColumnCategoryExtensions.RemoveColumnsByCategory see RemoveColumnsByCategory_Succeeds
+        // in ConfigExtensionsTests.Columns.cs
+    }
+}

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
@@ -1,0 +1,225 @@
+// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using Xunit;
+
+namespace Mawosoft.Extensions.BenchmarkDotNet.Tests
+{
+    public partial class ConfigExtensionsTests
+    {
+        private static void AssertColumnsEqual(IConfig expected, IConfig actual)
+        {
+            List<Type> expectedResult = new();
+            List<Type> actualResult = new();
+            Flatten(expected.GetColumnProviders(), expectedResult);
+            Flatten(actual.GetColumnProviders(), actualResult);
+            Assert.Equal(expectedResult, actualResult);
+
+            static void Flatten(IEnumerable<IColumnProvider> providers, List<Type> result)
+            {
+                foreach (IColumnProvider provider in providers)
+                {
+                    result.Add(provider.GetType());
+                    switch (provider)
+                    {
+                        case CompositeColumnProvider:
+                            FieldInfo providersField = typeof(CompositeColumnProvider).GetField("providers",
+                                BindingFlags.Instance | BindingFlags.NonPublic)!;
+                            Assert.NotNull(providersField);
+                            IColumnProvider[] subProviders =
+                                (providersField.GetValue(provider) as IColumnProvider[])!;
+                            Assert.NotNull(subProviders);
+                            Flatten(subProviders, result);
+                            break;
+                        case SimpleColumnProvider simple:
+                            FieldInfo columnsField = typeof(SimpleColumnProvider).GetField("columns",
+                                BindingFlags.Instance | BindingFlags.NonPublic)!;
+                            Assert.NotNull(columnsField);
+                            IColumn[] columns = (columnsField?.GetValue(provider) as IColumn[])!;
+                            Assert.NotNull(columns);
+                            result.AddRange(columns.Select(c => c.GetType()));
+                            break;
+                    }
+                }
+            }
+        }
+
+        private class ReplaceColumnCategory_WithColumns_TheoryData : TheoryData<IColumnProvider[], IColumn[], IColumnProvider[]>
+        {
+            public ReplaceColumnCategory_WithColumns_TheoryData()
+            {
+                Add(new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        DefaultColumnProviders.Statistics,
+                        DefaultColumnProviders.Params,
+                        DefaultColumnProviders.Metrics
+                    },
+                    new IColumn[]
+                    {
+                        StatisticColumn.Mean,
+                        new CombinedParamsColumn()
+                    },
+                    new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        DefaultColumnProviders.Metrics
+                    });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(ReplaceColumnCategory_WithColumns_TheoryData))]
+        public void ReplaceColumnCategory_WithColumns_Succeeds(IColumnProvider[] input, IColumn[] param, IColumnProvider[] expected)
+        {
+            IConfig inputIConfig = ManualConfig.CreateEmpty().AddColumnProvider(input);
+            ManualConfig inputManualConfig = CloneConfigExcept(inputIConfig, null);
+            IConfig expectedIConfig = ManualConfig.CreateEmpty().AddColumnProvider(expected).AddColumn(param);
+            IConfig actualIConfig = inputIConfig.ReplaceColumnCategory(param);
+            Assert.NotSame(inputIConfig, actualIConfig);
+            AssertColumnsEqual(expectedIConfig, actualIConfig);
+            ManualConfig actualManualConfig = inputManualConfig.ReplaceColumnCategory(param);
+            Assert.Same(inputManualConfig, actualManualConfig);
+            AssertColumnsEqual(expectedIConfig, actualManualConfig);
+        }
+
+        private class ReplaceColumnCategory_WithProviders_TheoryData : TheoryData<IColumnProvider[], IColumnProvider[], IColumnProvider[]>
+        {
+            public ReplaceColumnCategory_WithProviders_TheoryData()
+            {
+                Add(new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        DefaultColumnProviders.Statistics,
+                        DefaultColumnProviders.Params,
+                        DefaultColumnProviders.Metrics
+                    },
+                    new IColumnProvider[]
+                    {
+                        new JobColumnSelectionProvider("-all +job"),
+                        new RecyclableParamsColumnProvider()
+                    },
+                    new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Statistics,
+                        DefaultColumnProviders.Metrics
+                    });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(ReplaceColumnCategory_WithProviders_TheoryData))]
+        public void ReplaceColumnCategory_WithProviders_Succeeds(IColumnProvider[] input, IColumnProvider[] param, IColumnProvider[] expected)
+        {
+            IConfig inputIConfig = ManualConfig.CreateEmpty().AddColumnProvider(input);
+            ManualConfig inputManualConfig = CloneConfigExcept(inputIConfig, null);
+            IConfig expectedIConfig = ManualConfig.CreateEmpty().AddColumnProvider(expected).AddColumnProvider(param);
+            IConfig actualIConfig = inputIConfig.ReplaceColumnCategory(param);
+            Assert.NotSame(inputIConfig, actualIConfig);
+            AssertColumnsEqual(expectedIConfig, actualIConfig);
+            ManualConfig actualManualConfig = inputManualConfig.ReplaceColumnCategory(param);
+            Assert.Same(inputManualConfig, actualManualConfig);
+            AssertColumnsEqual(expectedIConfig, actualManualConfig);
+        }
+
+        private class RemoveColumnsByCategory_TheoryData : TheoryData<IColumnProvider[], ColumnCategory[], IColumnProvider[]>
+        {
+            public RemoveColumnsByCategory_TheoryData()
+            {
+                Add(new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        DefaultColumnProviders.Statistics,
+                        DefaultColumnProviders.Params,
+                        DefaultColumnProviders.Metrics
+                    },
+                    new ColumnCategory[] { ColumnCategory.Job, ColumnCategory.Statistics },
+                    new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Params,
+                        DefaultColumnProviders.Metrics
+                    });
+                Add(new IColumnProvider[]
+                    {
+                        new CompositeColumnProvider
+                        (
+                            DefaultColumnProviders.Descriptor,
+                            DefaultColumnProviders.Job,
+                            new SimpleColumnProvider
+                            (
+                                StatisticColumn.Max,
+                                CategoriesColumn.Default,
+                                new ParamColumn("param")
+                            ),
+                            DefaultColumnProviders.Statistics,
+                            DefaultColumnProviders.Params,
+                            DefaultColumnProviders.Metrics
+                        )
+                    },
+                    new ColumnCategory[] { ColumnCategory.Statistics, ColumnCategory.Params},
+                    new IColumnProvider[]
+                    {
+                        new CompositeColumnProvider
+                        (
+                            DefaultColumnProviders.Descriptor,
+                            DefaultColumnProviders.Job,
+                            new SimpleColumnProvider
+                            (
+                                CategoriesColumn.Default
+                            ),
+                            DefaultColumnProviders.Metrics
+                        )
+                    });
+                Add(new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        new CompositeColumnProvider
+                        (
+                            DefaultColumnProviders.Statistics,
+                            DefaultColumnProviders.Params
+                        ),
+                        new SimpleColumnProvider
+                        (
+                            StatisticColumn.Max,
+                            new ParamColumn("param")
+                        ),
+                        DefaultColumnProviders.Metrics
+                    },
+                    new ColumnCategory[] { ColumnCategory.Statistics, ColumnCategory.Params },
+                    new IColumnProvider[]
+                    {
+                        DefaultColumnProviders.Descriptor,
+                        DefaultColumnProviders.Job,
+                        DefaultColumnProviders.Metrics
+                    });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(RemoveColumnsByCategory_TheoryData))]
+        public void RemoveColumnsByCategory_Succeeds(IColumnProvider[] input, ColumnCategory[] param, IColumnProvider[] expected)
+        {
+            IConfig inputIConfig = ManualConfig.CreateEmpty().AddColumnProvider(input);
+            ManualConfig inputManualConfig = CloneConfigExcept(inputIConfig, null);
+            IConfig expectedIConfig = ManualConfig.CreateEmpty().AddColumnProvider(expected);
+            IConfig actualIConfig = inputIConfig.RemoveColumnsByCategory(param);
+            Assert.NotSame(inputIConfig, actualIConfig);
+            AssertColumnsEqual(expectedIConfig, actualIConfig);
+            ManualConfig actualManualConfig = inputManualConfig.RemoveColumnsByCategory(param);
+            Assert.Same(inputManualConfig, actualManualConfig);
+            AssertColumnsEqual(expectedIConfig, actualManualConfig);
+        }
+    }
+}

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
@@ -1,0 +1,279 @@
+// Copyright (c) 2021-2022 Matthias Wolf, Mawosoft.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Exporters.Xml;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Validators;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mawosoft.Extensions.BenchmarkDotNet.Tests
+{
+    public partial class ConfigExtensionsTests
+    {
+        private static readonly Lazy<List<(Type item, MethodInfo add, MethodInfo get)>> s_methodPairs = new(() =>
+        {
+            IEnumerable<MethodInfo> getter = typeof(IConfig)
+                .GetMethods()
+                .Where(m => !m.IsSpecialName
+                            && m.ReturnType.IsGenericType
+                            && typeof(IEnumerable).IsAssignableFrom(m.ReturnType));
+            Assert.Equal(10, getter.Count());
+            (MethodInfo m, Type? t)[] adder = typeof(ManualConfig)
+                .GetMethods()
+                .Where(m => !m.IsSpecialName
+                            && m.ReturnType == typeof(ManualConfig)
+                            && m.Name != "AddColumn"
+                            && m.Name.StartsWith("Add", StringComparison.Ordinal))
+                .Select(m =>
+                {
+                    Type? retType = null;
+                    ParameterInfo[] pi = m.GetParameters();
+                    if (pi.Length == 1 && pi[0].ParameterType.IsArray)
+                    {
+                        retType = pi[0].ParameterType.GetElementType();
+                    }
+                    return (m, retType);
+                }).ToArray();
+            return getter.Select(g =>
+            {
+                Type t = g.ReturnType.GetGenericArguments().Single();
+                return (t, adder.Single(mt => mt.t == t).m, g);
+            }).ToList();
+        });
+
+        private static ManualConfig CloneConfigExcept(IConfig source, Type? itemTypeToExclude)
+        {
+            ManualConfig config = ManualConfig.CreateEmpty();
+            MethodInfo genericToArray = typeof(Enumerable).GetMethod("ToArray")!;
+            Assert.NotNull(genericToArray);
+            foreach ((Type item, MethodInfo add, MethodInfo get) in s_methodPairs.Value)
+            {
+                if (item == itemTypeToExclude) continue;
+                object? retVal = get.Invoke(source, Array.Empty<object?>());
+                retVal = genericToArray.MakeGenericMethod(item).Invoke(null, new object?[] { retVal });
+                add.Invoke(config, new object?[] { retVal });
+            }
+            config.Orderer = source.Orderer;
+            config.SummaryStyle = source.SummaryStyle;
+            config.UnionRule = source.UnionRule;
+            config.ArtifactsPath = source.ArtifactsPath;
+            config.CultureInfo = source.CultureInfo;
+            config.Options = source.Options;
+            return config;
+        }
+
+        private static void AssertConfigEqual(IConfig expected, IConfig actual)
+        {
+            foreach ((_, _, MethodInfo get) in s_methodPairs.Value)
+            {
+                object? retLeft = get.Invoke(expected, Array.Empty<object?>());
+                object? retRight = get.Invoke(actual, Array.Empty<object?>());
+                Assert.Equal(retLeft, retRight);
+            }
+            Assert.Equal(expected.Orderer, actual.Orderer);
+            Assert.Equal(expected.SummaryStyle, actual.SummaryStyle);
+            Assert.Equal(expected.UnionRule, actual.UnionRule);
+            Assert.Equal(expected.ArtifactsPath, actual.ArtifactsPath);
+            Assert.Equal(expected.CultureInfo, actual.CultureInfo);
+            Assert.Equal(expected.Options, actual.Options);
+        }
+
+        private static ManualConfig CreateSourceConfig()
+            => CloneConfigExcept(DefaultConfig.Instance, typeof(IAnalyser))
+                .AddDiagnoser(ThreadingDiagnoser.Default,
+                              new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig()))
+                .AddAnalyser(RuntimeErrorAnalyser.Default, ZeroMeasurementAnalyser.Default,
+                             BaselineCustomAnalyzer.Default)
+                .AddJob(Job.Dry, Job.VeryLongRun)
+                .AddHardwareCounters(HardwareCounter.BranchInstructionRetired,
+                                     HardwareCounter.BranchInstructions)
+                .AddFilter(new SimpleFilter(b => true))
+                .AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByCategory);
+
+        private struct TestCaseData
+        {
+            public ManualConfig ExpectedNeedsAdd;
+            public IConfig IConfigRemove;
+            public ManualConfig ManualConfigRemove;
+            public IConfig IConfigReplace;
+            public ManualConfig ManualConfigReplace;
+        }
+
+        private static void RunReplaceTestCase(Type itemType, Func<TestCaseData, TestCaseData> itemTestHandler)
+        {
+            TestCaseData input;
+            ManualConfig config = CreateSourceConfig();
+            input.IConfigRemove = CloneConfigExcept(config, null);
+            input.ManualConfigRemove = CloneConfigExcept(config, null);
+            input.IConfigReplace = CloneConfigExcept(config, null);
+            input.ManualConfigReplace = CloneConfigExcept(config, null);
+            input.ExpectedNeedsAdd = CloneConfigExcept(config, itemType);
+            ManualConfig expectedRemove = CloneConfigExcept(config, itemType);
+            TestCaseData actual = itemTestHandler(input);
+            Assert.NotSame(actual.IConfigRemove, input.IConfigRemove);
+            Assert.NotSame(actual.IConfigReplace, input.IConfigReplace);
+            Assert.Same(actual.ManualConfigRemove, input.ManualConfigRemove);
+            Assert.Same(actual.ManualConfigReplace, input.ManualConfigReplace);
+            AssertConfigEqual(expectedRemove, actual.IConfigRemove);
+            AssertConfigEqual(expectedRemove, actual.ManualConfigRemove);
+            AssertConfigEqual(actual.ExpectedNeedsAdd, actual.IConfigReplace);
+            AssertConfigEqual(actual.ExpectedNeedsAdd, actual.ManualConfigReplace);
+        }
+
+        [Fact]
+        public void ReplaceExporters_Succeeds()
+        {
+            RunReplaceTestCase(typeof(IExporter), input =>
+            {
+                var replacements = new IExporter[] { JsonExporter.Brief, XmlExporter.Brief };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddExporter(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceExporters();
+                result.IConfigReplace = input.IConfigReplace.ReplaceExporters(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceExporters();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceExporters(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceLoggers_Succeeds()
+        {
+            RunReplaceTestCase(typeof(ILogger), input =>
+            {
+                var replacements = new ILogger[] { ConsoleLogger.Unicode, new LogCapture() };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddLogger(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceLoggers();
+                result.IConfigReplace = input.IConfigReplace.ReplaceLoggers(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceLoggers();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceLoggers(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceDiagnosers_Succeeds()
+        {
+            RunReplaceTestCase(typeof(IDiagnoser), input =>
+            {
+                var replacements = new IDiagnoser[] { new MemoryDiagnoser(new MemoryDiagnoserConfig()) };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddDiagnoser(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceDiagnosers();
+                result.IConfigReplace = input.IConfigReplace.ReplaceDiagnosers(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceDiagnosers();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceDiagnosers(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceAnalysers_Succeeds()
+        {
+            RunReplaceTestCase(typeof(IAnalyser), input =>
+            {
+                var replacements = new IAnalyser[] { EnvironmentAnalyser.Default, OutliersAnalyser.Default };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddAnalyser(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceAnalysers();
+                result.IConfigReplace = input.IConfigReplace.ReplaceAnalysers(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceAnalysers();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceAnalysers(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceJobs_Succeeds()
+        {
+            RunReplaceTestCase(typeof(Job), input =>
+            {
+                var replacements = new Job[] { Job.Dry, Job.ShortRun };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddJob(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceJobs();
+                result.IConfigReplace = input.IConfigReplace.ReplaceJobs(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceJobs();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceJobs(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceValidators_Succeeds()
+        {
+            RunReplaceTestCase(typeof(IValidator), input =>
+            {
+                var replacements = new IValidator[] { ShadowCopyValidator.DontFailOnError };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddValidator(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceValidators();
+                result.IConfigReplace = input.IConfigReplace.ReplaceValidators(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceValidators();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceValidators(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceHardwareCounters_Succeeds()
+        {
+            RunReplaceTestCase(typeof(HardwareCounter), input =>
+            {
+                var replacements = new HardwareCounter[] { HardwareCounter.BranchMispredictions, HardwareCounter.BranchMispredictsRetired, HardwareCounter.CacheMisses  };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddHardwareCounters(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceHardwareCounters();
+                result.IConfigReplace = input.IConfigReplace.ReplaceHardwareCounters(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceHardwareCounters();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceHardwareCounters(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceFilters_Succeeds()
+        {
+            RunReplaceTestCase(typeof(IFilter), input =>
+            {
+                var replacements = new IFilter[] { new NameFilter(n => true), new WhatifFilter()  };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddFilter(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceFilters();
+                result.IConfigReplace = input.IConfigReplace.ReplaceFilters(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceFilters();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceFilters(replacements);
+                return result;
+            });
+        }
+
+        [Fact]
+        public void ReplaceLogicalGroupRules_Succeeds()
+        {
+            RunReplaceTestCase(typeof(BenchmarkLogicalGroupRule), input =>
+            {
+                var replacements = new BenchmarkLogicalGroupRule[] { BenchmarkLogicalGroupRule.ByJob, BenchmarkLogicalGroupRule.ByMethod };
+                TestCaseData result;
+                result.ExpectedNeedsAdd = input.ExpectedNeedsAdd.AddLogicalGroupRules(replacements);
+                result.IConfigRemove = input.IConfigRemove.ReplaceLogicalGroupRules();
+                result.IConfigReplace = input.IConfigReplace.ReplaceLogicalGroupRules(replacements);
+                result.ManualConfigRemove = input.ManualConfigRemove.ReplaceLogicalGroupRules();
+                result.ManualConfigReplace = input.ManualConfigReplace.ReplaceLogicalGroupRules(replacements);
+                return result;
+            });
+        }
+    }
+}

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
@@ -14,9 +14,6 @@
 
   <ItemGroup>
     <PackageReference Update ="@(PackageVersion)" Version="%(PackageVersion.Version)"></PackageReference>
-    <!-- Highest version does not necessarly reflect latest BDN master build.
-         See https://github.com/dotnet/BenchmarkDotNet/issues/1922 -->
-    <!--<PackageReference Update="BenchmarkDotNet" Version="*-*"></PackageReference>-->
-    <PackageReference Update="BenchmarkDotNet" Version="0.13.1.1696"></PackageReference>
+    <PackageReference Update="BenchmarkDotNet" Version="*-*"></PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Tolerate implementation changes in ManualConfig.GetXxx() Closes #25.
- Tolerate breaking API changes in BenchmarkReport.ctor() and others. See #27.
- Unpin NightlyBDN (Issue resolved https://github.com/dotnet/BenchmarkDotNet/issues/1922).
- Add tests.