### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,7 @@ jobs:
         # Parallel builds causing trouble here
         exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore -bl:./Binlogs/build_MEB_debug.binlog }
         exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore -bl:./Binlogs/build_MEB_release.binlog }
-        # DocFx build temporarly disabled for -c Debug
-        exec { dotnet build -c Debug --no-restore -bl:./Binlogs/build_debug.binlog /p:BuildDocFx=false }
+        exec { dotnet build -c Debug --no-restore -bl:./Binlogs/build_debug.binlog }
         exec { dotnet build -c Release --no-restore -bl:./Binlogs/build_release.binlog /p:BuildDocFx=false }
         exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages -bl:./Binlogs/pack.binlog }
     - name: Upload Binlogs
@@ -100,8 +99,7 @@ jobs:
         name: Packages
         path: ./Packages/
     - name: Upload Docs Website
-      # DocFx build temporarly disabled
-      if: false # ${{ matrix.os == 'ubuntu-latest' || strategy.job-total == 1 }}
+      if: ${{ matrix.os == 'ubuntu-latest' || strategy.job-total == 1 }}
       uses: actions/upload-artifact@v2
       with:
         name: DocsWebsite

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <Deterministic>$(CI)</Deterministic>
+    <!-- Regression in .NET SDK 6.0.300 when using Central Package Management:
+         NU1507 if multiple feeds are used without package source mapping. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Re-enable DocFx build
- Suppress NU1507 warning caused by a regression in .NET SDK 6.0.300