### PR TITLE
Fix CI workflow and optimize workflow for BDN API Compat Check

### DIFF
--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -76,12 +76,12 @@ jobs:
     - name: DotNet Info
       run: dotnet --info
     - name: DotNet Setup
-      if: ${{ matrix.os == 'macos-latest' }
+      if: ${{ matrix.os == 'macos-latest' }}
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x      
     - name: DotNet Info
-      if: ${{ matrix.os == 'macos-latest' }
+      if: ${{ matrix.os == 'macos-latest' }}
       run: dotnet --info
     - name: Build
       env:

--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -75,29 +75,38 @@ jobs:
         fetch-depth: 1
     - name: DotNet Info
       run: dotnet --info
+    - name: DotNet Setup
+      if: ${{ matrix.os == 'macos-latest' }
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x      
+    - name: DotNet Info
+      if: ${{ matrix.os == 'macos-latest' }
+      run: dotnet --info
     - name: Build
+      env:
+        MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
       run: |
         . ./build/startNativeExecution.ps1
         Set-Alias exec Start-NativeExecution
-        $BDNNightlyVersion = '${{ needs.ApiCompat.outputs.LastCheckedVersion }}'
-        exec { dotnet restore "-p:BDNNightlyVersion=$BDNNightlyVersion" -bl:./Binlogs/restore.binlog }
-        # Parallel builds causing trouble here
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore -bl:./Binlogs/build_MEB_debug.binlog }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore -bl:./Binlogs/build_MEB_release.binlog }
-        exec { dotnet build -c Debug --no-restore -bl:./Binlogs/build_debug.binlog /p:BuildDocFx=false }
-        exec { dotnet build -c Release --no-restore -bl:./Binlogs/build_release.binlog /p:BuildDocFx=false }
+        $BdnNightlyVersion = '${{ needs.ApiCompat.outputs.LastCheckedVersion }}'
+        exec { dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion" }
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
+        exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore }
+        exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Release --no-restore }
     - name: Upload Binlogs
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-Binlogs
-        path: ./Binlogs/
+        path: '**/MSBuild_Logs/*'
     - name: Test
       id: test
       run: |
         $tfms = @("net5.0")
         if ($IsWindows) { $tfms += "net461" }
-        ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
+        ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
       if: ${{ failure() && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
     - name: DotNet Info
       run: dotnet --info
     - name: DotNet Setup
-      if: ${{ matrix.os == 'macos-latest' }
+      if: ${{ matrix.os == 'macos-latest' }}
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x      
     - name: DotNet Info
-      if: ${{ matrix.os == 'macos-latest' }
+      if: ${{ matrix.os == 'macos-latest' }}
       run: dotnet --info
     - name: Build
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,25 +74,34 @@ jobs:
         fetch-depth: 0
     - name: DotNet Info
       run: dotnet --info
+    - name: DotNet Setup
+      if: ${{ matrix.os == 'macos-latest' }
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x      
+    - name: DotNet Info
+      if: ${{ matrix.os == 'macos-latest' }
+      run: dotnet --info
     - name: Build
+      env:
+        MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
       run: |
         . ./build/startNativeExecution.ps1
         Set-Alias exec Start-NativeExecution
-        $BDNNightlyVersion = & ./build/findLatestBdnNightlyVersion.ps1 -Verbose
-        exec { dotnet restore "-p:BDNNightlyVersion=$BDNNightlyVersion" -bl:./Binlogs/restore.binlog }
+        $BdnNightlyVersion = & ./build/findLatestBdnNightlyVersion.ps1 -Verbose
+        exec { dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion" }
         # Parallel builds causing trouble here
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore -bl:./Binlogs/build_MEB_debug.binlog }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore -bl:./Binlogs/build_MEB_release.binlog }
-        # DocFx build temporarly disabled for -c Debug
-        exec { dotnet build -c Debug --no-restore -bl:./Binlogs/build_debug.binlog /p:BuildDocFx=false }
-        exec { dotnet build -c Release --no-restore -bl:./Binlogs/build_release.binlog /p:BuildDocFx=false }
-        exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages -bl:./Binlogs/pack.binlog }
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
+        exec { dotnet build -c Debug --no-restore }
+        exec { dotnet build -c Release --no-restore }
+        exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages }
     - name: Upload Binlogs
       if: ${{ failure() || github.event_name == 'workflow_dispatch' }}
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-Binlogs
-        path: ./Binlogs/
+        path: '**/MSBuild_Logs/*'
     - name: Upload Packages
       if: ${{ matrix.os == 'ubuntu-latest' || strategy.job-total == 1 }}
       uses: actions/upload-artifact@v2
@@ -100,8 +109,7 @@ jobs:
         name: Packages
         path: ./Packages/
     - name: Upload Docs Website
-      # DocFx build temporarly disabled
-      if: false # ${{ matrix.os == 'ubuntu-latest' || strategy.job-total == 1 }}
+      if: ${{ matrix.os == 'ubuntu-latest' || strategy.job-total == 1 }}
       uses: actions/upload-artifact@v2
       with:
         name: DocsWebsite

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <Deterministic>$(CI)</Deterministic>
+    <!-- Regression in .NET SDK 6.0.300 when using Central Package Management:
+         NU1507 if multiple feeds are used without package source mapping. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Fix CI workflow
- Install missing .NET 6 SDK on macos-latest.
- Use environment variable MSBuildDebugEngine for binlog creation instead of -bl switch.
- Add global.json to prevent DocFx on ubuntu-latest from using the wrong .NET SDK for internal builds.
- Re-enable DocFx build
- Suppress NU1507 warning caused by a regression in .NET SDK 6.0.300
Fixes #69
Closes #64

Optimize workflow for BDN API Compat Check
- Install missing .NET 6 SDK on macos-latest.
- Use environment variable MSBuildDebugEngine for binlog creation instead of -bl switch.
- Only build and run the NightlyBDN tests, nothing else.
Closes #70
