### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,8 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Pinning still has some kinks. See https://github.com/NuGet/Home/issues/11952 -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <Deterministic>$(CI)</Deterministic>
     <!-- Regression in .NET SDK 6.0.300 when using Central Package Management:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,19 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="docfx.console" Version="2.59.2" />
+    <PackageVersion Include="docfx.console" Version="2.59.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="System.Management" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Transitive pinning for vulnerable packages -->
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <BDNNightlyVersion Condition="'$(BDNNightlyVersion)' == ''">*-*</BDNNightlyVersion>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    <RestoreNoCache>true</RestoreNoCache>
     <!-- These work with both msbuild console builds and VStudio 2019 builds.
          - RestoreAdditionalProjectSources, RestoreSources
          These don't work in VStudio 2019 builds
@@ -14,8 +12,7 @@
   <Import Project="$(MSBuildThisFileDirectory)../Mawosoft.Extensions.BenchmarkDotNet.Tests.proj" />
 
   <ItemGroup>
-    <PackageReference Update ="@(PackageVersion)" Version="%(PackageVersion.Version)"></PackageReference>
-    <PackageReference Update="BenchmarkDotNet" Version="$(BDNNightlyVersion)"></PackageReference>
+    <PackageReference Include="BenchmarkDotNet" VersionOverride="$(BDNNightlyVersion)"></PackageReference>
   </ItemGroup>
 
   <Target Name="FindBdnNightly" Condition="'$(CI)' != 'true' and ('$(BDNNightlyVersion)' == '' or '$(BDNNightlyVersion)' == '*-*')"  BeforeTargets="CollectPackageReferences">
@@ -28,7 +25,7 @@
               TaskParameter="ConsoleOutput" PropertyName="BDNNightlyVersion" />
     </Exec>
     <ItemGroup>
-      <PackageReference Condition="'%(Identity)' == 'BenchmarkDotNet'" Version="$(BDNNightlyVersion)"></PackageReference>
+      <PackageReference Condition="'%(Identity)' == 'BenchmarkDotNet'" VersionOverride="$(BDNNightlyVersion)"></PackageReference>
     </ItemGroup>
   </Target>
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
@@ -12,7 +12,12 @@
   <Import Project="$(MSBuildThisFileDirectory)../Mawosoft.Extensions.BenchmarkDotNet.Tests.proj" />
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" VersionOverride="$(BDNNightlyVersion)"></PackageReference>
+    <!-- Just specifying VersionOverride on Include doesn't work. Somehow the reference has been already included
+         and Include here adds a duplicate that later gets removed. 
+         The Include here is not strictly necessary, Update alone would be sufficient. However, using Update
+         with a nonexisting identity would not produce any error or warning, so better safe than sorry. -->
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Update="BenchmarkDotNet" VersionOverride="$(BDNNightlyVersion)" />
   </ItemGroup>
 
   <Target Name="FindBdnNightly" Condition="'$(CI)' != 'true' and ('$(BDNNightlyVersion)' == '' or '$(BDNNightlyVersion)' == '*-*')"  BeforeTargets="CollectPackageReferences">


### PR DESCRIPTION
- Bump docfx.console to 2.59.3
- Use transitive pinning for vulnerable packages (System.Net.Http, System.Text.RegularExpressions, Newtonsoft.Json)
- In Tests.NightlyBDN, use VersionOverride instead of disabling ManagePackageVersionsCentrally.
Closes #90, closes #97.