### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,7 @@
     <PackageVersion Include="docfx.console" Version="2.59.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="System.Management" Version="6.0.0" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
@@ -16,6 +15,8 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Transitive pinning for bug caused by outdated ref in BDN 0.13.1 -->
+    <PackageVersion Include="System.Management" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
@@ -33,9 +33,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <!-- Referencing 6.0.0 only to fix outdated ref in BenchmarkDotNet.
-         Should no longer be necessary in 0.13.2 -->
-    <PackageReference Include="System.Management" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Bump xunit to 2.4.2 (Closes #105)
- Use transitive pinning for System.Management (Contributes to #104)