### PR TITLE
Upgrade workflows

### DIFF
--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -78,6 +78,11 @@ jobs:
     - name: Build
       env:
         MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
+        # Fix incomplete binlogs in MSBuild <=17.3.x. See https://github.com/mawosoft/Mawosoft.Extensions.BenchmarkDotNet/issues/146
+        MSBUILDLOGTASKINPUTS: 1
+        MSBUILDTARGETOUTPUTLOGGING: true
+        MSBUILDLOGIMPORTS: 1
+        MSBUILDLOGALLENVIRONMENTVARIABLES: true
       run: |
         . ./build/startNativeExecution.ps1
         Set-Alias exec Start-NativeExecution
@@ -88,7 +93,7 @@ jobs:
         exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore }
         exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Release --no-restore }
     - name: Upload Binlogs
-      if: ${{ failure() }}
+      if: ${{ failure() || github.event_name == 'workflow_dispatch' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-Binlogs
@@ -100,7 +105,7 @@ jobs:
         if ($IsWindows) { $tfms += "net462" }
         ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
-      if: ${{ failure() && steps.test.outcome != 'skipped' }}
+      if: ${{ (failure() || github.event_name == 'workflow_dispatch') && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-Testresults

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,6 @@ jobs:
         Set-Alias exec Start-NativeExecution
         $BdnNightlyVersion = & ./build/findLatestBdnNightlyVersion.ps1 -Verbose
         exec { dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion" }
-        # Parallel builds causing trouble here
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
         exec { dotnet build -c Debug --no-restore }
         exec { dotnet build -c Release --no-restore /p:BuildDocFx=false }
         exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         Set-Alias exec Start-NativeExecution
         $BdnNightlyVersion = & ./build/findLatestBdnNightlyVersion.ps1 -Verbose
         exec { dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion" }
+        # Parallel builds causing trouble here
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
+        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
         exec { dotnet build -c Debug --no-restore }
         exec { dotnet build -c Release --no-restore /p:BuildDocFx=false }
         exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         if ($${{ github.event.inputs.os != 'matrix' && github.event.inputs.os != '' }}) {
           $os = "[""${{ github.event.inputs.os }}""]"
         }
-        Write-Host "::set-output name=os::$os"
+        echo "os=$os" >>$env:GITHUB_OUTPUT
     outputs:
       matrix_os: ${{ steps.prep.outputs.os }}
 
@@ -127,8 +127,8 @@ jobs:
           $release = "v$version"
         }
         Write-Host "Version: $version, Deploy: $deploy, Release: $release"
-        Write-Host "::set-output name=deploy::$deploy"
-        Write-Host "::set-output name=release::$release"
+        echo "deploy=$deploy" >>$env:GITHUB_OUTPUT
+        echo "release=$release" >>$env:GITHUB_OUTPUT
     - name: Test
       id: test
       if: ${{ github.event.inputs.skip-tests != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
     - name: Build
       env:
         MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
+        # Fix incomplete binlogs in MSBuild <=17.3.x. See https://github.com/mawosoft/Mawosoft.Extensions.BenchmarkDotNet/issues/146
+        MSBUILDLOGTASKINPUTS: 1
+        MSBUILDTARGETOUTPUTLOGGING: true
+        MSBUILDLOGIMPORTS: 1
+        MSBUILDLOGALLENVIRONMENTVARIABLES: true
       run: |
         . ./build/startNativeExecution.ps1
         Set-Alias exec Start-NativeExecution
@@ -89,7 +94,7 @@ jobs:
         exec { dotnet build -c Release --no-restore /p:BuildDocFx=false }
         exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages }
     - name: Upload Binlogs
-      if: ${{ failure() || github.event_name == 'workflow_dispatch' }}
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-Binlogs

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,7 @@
     <!-- Regression in .NET SDK 6.0.300 when using Central Package Management:
          NU1507 if multiple feeds are used without package source mapping. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
+    <TreatWarningsAsErrors Condition="'$(CI)' == 'true'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -15,13 +15,18 @@ pr:
   branches: { include: [master] }
 
 pool:
-  vmImage: ubuntu-latest
+  vmImage: windows-latest
 
 variables:
   disable.coverage.autogenerate: true
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 steps:
 - checkout: self
+- pwsh: dotnet --info
+  displayName: DotNet Info
 - pwsh: |
     . ./build/startNativeExecution.ps1
     Set-Alias exec Start-NativeExecution
@@ -31,19 +36,30 @@ steps:
     exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj -c Debug --no-restore }
     exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore }
   displayName: Build
-- pwsh: ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net6.0 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
+  env:
+    MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
+    # Fix incomplete binlogs in MSBuild <=17.3.x. See https://github.com/mawosoft/Mawosoft.Extensions.BenchmarkDotNet/issues/146
+    MSBUILDLOGTASKINPUTS: 1
+    MSBUILDTARGETOUTPUTLOGGING: true
+    MSBUILDLOGIMPORTS: 1
+    MSBUILDLOGALLENVIRONMENTVARIABLES: true
+- publish: ./MSBuild_Logs
+  condition: succeededOrFailed()
+  artifact: azp-Binlogs
+  displayName: Upload Binlogs
+- pwsh: ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net6.0, net462 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
   displayName: Test
 - task: reportgenerator@5
   condition: succeededOrFailed()
   inputs:
-    reports: ./TestResults/*/Debug/net6.0/*.xml
+    reports: ./TestResults/*/Debug/*/*.xml
     targetdir: ./TestResults/report
     reporttypes: Cobertura;HtmlInline_AzurePipelines
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:
     testResultsFormat: VSTest
-    testResultsFiles: '*/Debug/net6.0/*.trx'
+    testResultsFiles: '*/Debug/*/*.trx'
     searchFolder: ./TestResults
     publishRunAttachments: false
 - task: PublishCodeCoverageResults@1
@@ -52,9 +68,8 @@ steps:
     codeCoverageTool: Cobertura
     summaryFileLocation: ./TestResults/report/Cobertura.xml
     reportDirectory: ./TestResults/report
-- bash: |
-    curl -o "./codecov" -s https://uploader.codecov.io/latest/linux/codecov
-    chmod +x "./codecov"
-    "./codecov" -f ./TestResults/report/Cobertura.xml -t $(CODECOV_TOKEN)
+- pwsh: |
+    $null = Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -OutFile ./codecov.exe
+    ./codecov.exe -f ./TestResults/report/Cobertura.xml -t $(CODECOV_TOKEN)
   condition: succeededOrFailed()
   displayName: Upload to codecov.io

--- a/build/checkToolDependencies.ps1
+++ b/build/checkToolDependencies.ps1
@@ -43,7 +43,8 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = 'Stop'
 
 # GitHub data about current workflow run and repository
-if (-not $env:GITHUB_RUN_ID -or -not $env:GITHUB_RUN_NUMBER -or -not $env:GITHUB_REPOSITORY) {
+if (-not $env:GITHUB_RUN_ID -or -not $env:GITHUB_RUN_NUMBER -or
+    -not $env:GITHUB_REPOSITORY -or -not $env:GITHUB_OUTPUT) {
     throw 'GitHub environment variables are not defined.'
 }
 
@@ -100,8 +101,8 @@ if ($runNumber -gt 1) {
 # Update and save changes to artifact
 $monorepos.UpdateLatest()
 $monorepos.ToJson() | Set-Content $monoreposFile
-Write-Host "::set-output name=ArtifactName::$ArtifactName"
-Write-Host "::set-output name=ArtifactPath::$monoreposFile"
+Write-Output "ArtifactName=$ArtifactName" >>$env:GITHUB_OUTPUT
+Write-Output "ArtifactPath=$monoreposFile" >>$env:GITHUB_OUTPUT
 
 # Report updated paths and outdated packages
 # GetNewOutdatedPackages() accounts for the following special case:
@@ -179,6 +180,6 @@ else {
     if ($IssueLabels) { $params.labels = $IssueLabels }
     $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/issues"
     $issue = $params | ConvertTo-Json -EscapeHandling EscapeNonAscii | Invoke-RestMethod -Uri $uri -Method Post @auth
-    Write-Host "::set-output name=IssueNumber::$($issue.number)"
+    Write-Output "IssueNumber=$($issue.number)" >>$env:GITHUB_OUTPUT
     Write-Host "::notice::Created Tool Dependency Alert. Issue #$($issue.number): $($issue.html_url)"
 }


### PR DESCRIPTION
- [x] Use $env:GITHUB_OUTPUT instead of ::set-output:: in workflows
Closes #143
- [x] Ensure complete binlogs via addt'l MSBuild env vars.
Closes #146
Will probably be fixed in MSBuild 17.4. See:
  - dotnet/msbuild/issues/7780
  - dotnet/msbuild/pull/7897
- [x] Codecov: Include net462 tests on Azure Pipelines
Closes #141
- [x] TreatWarningsAsErrors=true for all CI builds
