### PR TITLE
Bump Arcade tools to 8.0.0-beta.22615.3

### DIFF
--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -40,13 +40,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - name: Setup dotnet (temp. fix)
-      # TODO upgrade Arcade tools instead
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
     - name: Check BDN API Compatibility
       id: apicompat
       run: |

--- a/build/ApiCompat/ApiCompatHelper.psm1
+++ b/build/ApiCompat/ApiCompatHelper.psm1
@@ -55,8 +55,13 @@ function Install-ApiCompatTools {
         if (-not $AsmDiffPkg -or -not $ApiCompatPkg) {
             throw 'Unable to restore ApiCompat tools.'
         }
-        $script:AsmDiffDll = Join-Path $AsmDiffPkg 'tools/netcoreapp3.1/any/Microsoft.DotNet.AsmDiff.dll'
-        $script:ApiCompatDll = Join-Path $ApiCompatPkg 'tools/netcoreapp3.1/Microsoft.DotNet.ApiCompat.dll'
+        $docElem = (Select-Xml -Path $restoreProjectFilePath -XPath '/*').Node
+        $script:AsmDiffDll = Join-Path $AsmDiffPkg -ChildPath (
+            Select-Xml -xml $docElem -XPath '//ns:PackageReference[@Include="Microsoft.DotNet.AsmDiff"]' -Namespace $xmlns
+        ).Node.RelativeToolPath
+        $script:ApiCompatDll = Join-Path $ApiCompatPkg -ChildPath (
+            Select-Xml -xml $docElem -XPath '//ns:PackageReference[@Include="Microsoft.DotNet.ApiCompat"]' -Namespace $xmlns
+        ).Node.RelativeToolPath
     }
     # Notes:
     # - If the type source is unchanged, Add-Type would not trow any error if adding it again.

--- a/build/ApiCompat/ApiCompatHelper.psm1
+++ b/build/ApiCompat/ApiCompatHelper.psm1
@@ -56,6 +56,7 @@ function Install-ApiCompatTools {
             throw 'Unable to restore ApiCompat tools.'
         }
         $docElem = (Select-Xml -Path $restoreProjectFilePath -XPath '/*').Node
+        $xmlns = @{ ns = $docElem.NamespaceURI }
         $script:AsmDiffDll = Join-Path $AsmDiffPkg -ChildPath (
             Select-Xml -xml $docElem -XPath '//ns:PackageReference[@Include="Microsoft.DotNet.AsmDiff"]' -Namespace $xmlns
         ).Node.RelativeToolPath

--- a/build/ApiCompat/ToolRestore/ToolRestore.proj
+++ b/build/ApiCompat/ToolRestore/ToolRestore.proj
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22315.1" 
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="8.0.0-beta.22615.3" 
       ExcludeAssets="all" GeneratePathProperty="true"
-      RelativeToolPath="tools/netcoreapp3.1/Microsoft.DotNet.ApiCompat.dll"
+      RelativeToolPath="tools/net7.0/Microsoft.DotNet.ApiCompat.dll"
     />
-    <PackageReference Include="Microsoft.DotNet.AsmDiff" Version="7.0.0-beta.22315.1"
+    <PackageReference Include="Microsoft.DotNet.AsmDiff" Version="8.0.0-beta.22615.3"
       ExcludeAssets="all" GeneratePathProperty="true"
-      RelativeToolPath="tools/netcoreapp3.1/any/Microsoft.DotNet.AsmDiff.dll"
+      RelativeToolPath="tools/net7.0/any/Microsoft.DotNet.AsmDiff.dll"
     />
   </ItemGroup>
 


### PR DESCRIPTION
- Bump Arcade AsmDiff and ApiCompat to 8.0.0-beta.22615.3 (these versions target net7.0).
- Avoid duplicate tool path literals.
- Revert temp. use of dotnet SDK 3.1 in bdn-apicompat.yml

Closes #167.