### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,9 @@
 
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.4" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="docfx.console" Version="2.59.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.102",
+    "version": "7.0.203",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
- Use dotnet sdk >= 7.0.203.
- Bump coverlet.collector to 6.0.0.
- Bump Microsoft.NET.Test.Sdk to 17.6.2.

Closes #230.