### PR TITLE
Release 0.2.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,7 +44,7 @@
     <Company>Mawosoft</Company>
     <Product>Mawosoft.Extensions.BenchmarkDotNet</Product>
     <Copyright>Copyright (c) 2021-2023 Matthias Wolf, Mawosoft</Copyright>
-    <Version>0.2.6-dev</Version>
+    <Version>0.2.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,12 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="docfx.console" Version="2.59.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.7.0" />
     <PackageVersion Include="xunit" Version="2.5.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
   </ItemGroup>

--- a/build/checkBdnApiCompatibility.ps1
+++ b/build/checkBdnApiCompatibility.ps1
@@ -99,7 +99,7 @@ class BdnPackageInfo {
 class BdnPackageSet {
     static [string]$BaselineFeed = 'https://api.nuget.org/v3/index.json'
     static [string]$NightlyFeed = 'https://www.myget.org/F/benchmarkdotnet/api/v3/index.json'
-    static [string]$BaselineVersion = '0.13.7'
+    static [string]$BaselineVersion = '0.13.8'
     static [string]$DownloadProjectFilePath = (Join-Path $script:PSScriptRoot 'ApiCompat/BdnDownload/BdnDownload.proj')
     static [string]$NugetPackageRootPath = (Join-Path ([Environment]::GetFolderPath('UserProfile')) '.nuget/packages')
     static [ValidateNotNullOrEmpty()][BdnPackageInfo[]]$Infos = @(

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/SummaryWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/SummaryWrapper.cs
@@ -4,43 +4,6 @@ namespace Mawosoft.Extensions.BenchmarkDotNet.ApiCompat;
 
 internal static class SummaryWrapper
 {
-    private static readonly ConstructorInfo? s_ctorStable;
-    private static readonly ConstructorInfo? s_ctorNightly;
-
-    [SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline",
-        Justification = "Multiple interdependent fields.")]
-    static SummaryWrapper()
-    {
-        s_ctorStable = typeof(Summary).GetConstructor(new[]
-        {
-            typeof(string),
-            typeof(ImmutableArray<BenchmarkReport>),
-            typeof(HostEnvironmentInfo),
-            typeof(string),
-            typeof(string),
-            typeof(TimeSpan),
-            typeof(CultureInfo),
-            typeof(ImmutableArray<ValidationError>),
-            typeof(ImmutableArray<IColumnHidingRule>)
-        });
-        if (s_ctorStable is null)
-        {
-            s_ctorNightly = typeof(Summary).GetConstructor(new[]
-            {
-                typeof(string),
-                typeof(ImmutableArray<BenchmarkReport>),
-                typeof(HostEnvironmentInfo),
-                typeof(string),
-                typeof(string),
-                typeof(TimeSpan),
-                typeof(CultureInfo),
-                typeof(ImmutableArray<ValidationError>),
-                typeof(ImmutableArray<IColumnHidingRule>),
-                typeof(SummaryStyle)
-            });
-        }
-    }
-
     public static Summary Create(
         string title,
         ImmutableArray<BenchmarkReport> reports,
@@ -53,25 +16,7 @@ internal static class SummaryWrapper
         ImmutableArray<IColumnHidingRule> columnHidingRules,
         SummaryStyle? summaryStyle = null)
     {
-        if (s_ctorStable is not null)
-        {
-            return (Summary)s_ctorStable.Invoke(new object?[]
-            {
-                title,
-                reports,
-                hostEnvironmentInfo,
-                resultsDirectoryPath,
-                logFilePath,
-                totalTime,
-                cultureInfo,
-                validationErrors,
-                columnHidingRules
-            });
-        }
-        else if (s_ctorNightly is not null)
-        {
-            return (Summary)s_ctorNightly.Invoke(new object?[]
-            {
+        return new(
                 title,
                 reports,
                 hostEnvironmentInfo,
@@ -81,12 +26,6 @@ internal static class SummaryWrapper
                 cultureInfo,
                 validationErrors,
                 columnHidingRules,
-                summaryStyle
-            });
-        }
-        else
-        {
-            throw new MissingMethodException(nameof(Summary), ".ctor");
-        }
+                summaryStyle!);
     }
 }

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
@@ -19,7 +19,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <PackageReleaseNotes>This release supports BenchmarkDotNet 0.13.7 and BDN nightly builds up to at least 0.13.8-nightly.20230901.67</PackageReleaseNotes>
+    <PackageReleaseNotes>This release supports BenchmarkDotNet 0.13.8 and BDN nightly builds up to at least 0.13.9-nightly.20230922.72</PackageReleaseNotes>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>0.2.1</PackageValidationBaselineVersion>
   </PropertyGroup>

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/GlobalUsings.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/GlobalUsings.cs
@@ -20,5 +20,6 @@ global using BenchmarkDotNet.Loggers;
 global using BenchmarkDotNet.Reports;
 global using BenchmarkDotNet.Running;
 global using BenchmarkDotNet.Validators;
+global using NuGet.Versioning;
 global using Xunit;
 global using Xunit.Abstractions;

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/Mawosoft.Extensions.BenchmarkDotNet.Tests.proj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/Mawosoft.Extensions.BenchmarkDotNet.Tests.proj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
- Adjust for changes in BDN >= 0.13.8
- Simplify SummaryWrapper (currently no longer needed).
- Adjust tests for changes introduced in BDN 0.13.9-nightly.20230921.71/72. Only affects tests, not MEB itself.
- Update dependency to BDN 0.13.8.
- Set BDN apicompat baseline to BDN 0.13.8.
- Update package release notes.
- Closes #267, closes #269.