### PR TITLE
Update CI, Bump dependencies, Adjust for BDN changes.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ generated_code = true
 
 [*.cs]
 # IDE0073 File header
-file_header_template = Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+file_header_template = Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 # IDE0065 Using directive
 csharp_using_directive_placement = outside_namespace

--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -91,14 +91,14 @@ jobs:
         MSBUILDTARGETOUTPUTLOGGING: true
         MSBUILDLOGIMPORTS: 1
       run: |
-        . ./build/startNativeExecution.ps1
-        Set-Alias exec Start-NativeExecution
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         $BdnNightlyVersion = '${{ needs.ApiCompat.outputs.LastCheckedVersion }}'
-        exec { dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion" }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
-        exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore }
-        exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Release --no-restore }
+        dotnet restore "-p:BDNNightlyVersion=$BdnNightlyVersion"
+        dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore
+        dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore
+        dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore
+        dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Release --no-restore
     - name: Upload Binlogs
       if: ${{ failure() || github.event_name == 'workflow_dispatch' }}
       uses: actions/upload-artifact@v4
@@ -110,7 +110,7 @@ jobs:
       run: |
         $tfms = @("net7.0")
         if ($IsWindows) { $tfms += "net462" }
-        ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
+        ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
       if: ${{ (failure() || github.event_name == 'workflow_dispatch') && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/bdn-apicompat.yml
+++ b/.github/workflows/bdn-apicompat.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Test
       id: test
       run: |
-        $tfms = @("net7.0")
+        $tfms = @("net8.0")
         if ($IsWindows) { $tfms += "net462" }
         ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       id: test
       if: ${{ github.event.inputs.skip-tests != 'true' }}
       run: |
-        $tfms = @("net7.0")
+        $tfms = @("net8.0")
         if ($IsWindows) { $tfms += "net462" }
         ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
@@ -208,7 +208,7 @@ jobs:
         fetch-depth: 1
     - name: Create GitHub release
       # TODO release notes
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ needs.Build.outputs.release }}
         generate_release_notes: false # false is default. Seems to draw from PRs only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,15 @@ jobs:
         MSBUILDTARGETOUTPUTLOGGING: true
         MSBUILDLOGIMPORTS: 1
       run: |
-        . ./build/startNativeExecution.ps1
-        Set-Alias exec Start-NativeExecution
-        exec { dotnet restore }
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        dotnet restore
         # Parallel builds causing trouble here
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
-        exec { dotnet build -c Debug --no-restore }
-        exec { dotnet build -c Release --no-restore }
-        exec { dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages }
+        dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore
+        dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore
+        dotnet build -c Debug --no-restore
+        dotnet build -c Release --no-restore
+        dotnet pack ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-build -o ./Packages
     - name: Upload Binlogs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
@@ -141,7 +141,7 @@ jobs:
       run: |
         $tfms = @("net7.0")
         if ($IsWindows) { $tfms += "net462" }
-        ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
+        ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug, Release -f $tfms -v detailed -r ./TestResults -ff:$${{ strategy.fail-fast }}
     - name: Upload Test results
       if: ${{ always() && steps.test.outcome != 'skipped' }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/file-update.yml
+++ b/.github/workflows/file-update.yml
@@ -1,0 +1,64 @@
+name: Update Single File Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * 0'
+
+defaults:
+  run:
+    shell: pwsh
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
+        fetch-depth: 1
+    - name: Update
+      # Both must be set because dotnet-file internally calls gh cli to fetch the changelog.
+      env:
+        GCM_CREDENTIAL_STORE: cache
+        GH_TOKEN: ${{ github.token }}
+      id: update
+      run: |
+        dotnet tool update -g dotnet-file
+
+        [string]$tmpfile = New-TemporaryFile
+        dotnet-file update "-c:$tmpfile"
+
+        [string]$content = Get-Content $tmpfile -Raw
+        if (-not $content) {
+          'No changelog.'
+        }
+        else {
+          Write-Output 'Changelog<<EOF' >>$env:GITHUB_OUTPUT
+          Write-Output $content >>$env:GITHUB_OUTPUT
+          Write-Output 'EOF' >>$env:GITHUB_OUTPUT
+          $content
+        }
+    - name: Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        base: master
+        branch: dotnet-file-sync
+        delete-branch: true
+        labels: dependencies
+        title: Update Single File Dependencies
+        body: ${{ steps.update.outputs.Changelog }}
+        commit-message: |
+          Update Single File Dependencies
+
+          ${{ steps.sync.outputs.Changelog }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,11 +31,11 @@ jobs:
         global-json-file: ./global.json
     - name: DocFX Build
       run: |
-        . ./build/startNativeExecution.ps1
-        Set-Alias exec Start-NativeExecution
-        exec { dotnet restore }
-        exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore }
-        exec { dotnet build ./docs/docs.msbuildproj -c Release }
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        dotnet restore
+        dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Release --no-restore
+        dotnet build ./docs/docs.msbuildproj -c Release
     - name: Upload Binlogs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4

--- a/.netconfig
+++ b/.netconfig
@@ -1,0 +1,8 @@
+[file "build/invokeDotnetTest.ps1"]
+	url = https://github.com/mawosoft/misc-scripts/blob/master/CI/invokeDotnetTest.ps1
+	etag = cc6031ebe5f1fa538e001649d00114bbd38b916f1aa30118326b8f22abcd6e20
+	weak
+[file ".github/workflows/file-update.yml"]
+	url = https://github.com/mawosoft/misc-scripts/blob/master/CI/file-update.yml
+	etag = 2e1c88ec2f232763e4ff6b2d49128daf1e914676382b9c43fa0101b150d94206
+	weak

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
     <Authors>Matthias Wolf</Authors>
     <Company>Mawosoft</Company>
     <Product>Mawosoft.Extensions.BenchmarkDotNet</Product>
-    <Copyright>Copyright (c) 2021-2023 Matthias Wolf, Mawosoft</Copyright>
+    <Copyright>Copyright (c) 2021-2024 Matthias Wolf, Mawosoft</Copyright>
     <Version>0.2.7-dev</Version>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,8 +47,4 @@
     <Version>0.2.7-dev</Version>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
-  </ItemGroup>
-
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,19 +2,12 @@
 
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="docfx.console" Version="2.59.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.7.0" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Transitive pinning for vulnerable packages -->
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.9.1" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
 
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 Matthias Wolf
+Copyright (c) 2021-2024 Matthias Wolf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -47,7 +47,7 @@ steps:
   condition: succeededOrFailed()
   artifact: azp-Binlogs
   displayName: Upload Binlogs
-- pwsh: ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net7.0, net462 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
+- pwsh: ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net8.0, net462 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
   displayName: Test
 - task: reportgenerator@5
   condition: succeededOrFailed()

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -30,12 +30,12 @@ steps:
     Invoke-Expression "& { $(Invoke-RestMethod https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1) } -JsonFile ./global.json"
   displayName: Setup dotnet (pinned)
 - pwsh: |
-    . ./build/startNativeExecution.ps1
-    Set-Alias exec Start-NativeExecution
-    exec { dotnet restore }
-    exec { dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore }
-    exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj -c Debug --no-restore }
-    exec { dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore }
+    $ErrorActionPreference = 'Stop'
+    $PSNativeCommandUseErrorActionPreference = $true
+    dotnet restore
+    dotnet build ./src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj -c Debug --no-restore
+    dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj -c Debug --no-restore
+    dotnet build ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug --no-restore
   displayName: Build
   env:
     MSBuildDebugEngine: 1 # Auto-creates binlogs in ./MSBuild_Logs
@@ -47,7 +47,7 @@ steps:
   condition: succeededOrFailed()
   artifact: azp-Binlogs
   displayName: Upload Binlogs
-- pwsh: ./build/test.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net7.0, net462 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
+- pwsh: ./build/invokeDotnetTest.ps1 -p ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/StableBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.StableBDN.csproj, ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj -c Debug -f net7.0, net462 -v detailed -r ./TestResults -s ./tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/coverlet.runsettings
   displayName: Test
 - task: reportgenerator@5
   condition: succeededOrFailed()
@@ -63,6 +63,7 @@ steps:
     searchFolder: ./TestResults
     publishRunAttachments: false
 - task: PublishCodeCoverageResults@1
+  # Cannot use v2 with ReportGenerator
   condition: succeededOrFailed()
   inputs:
     codeCoverageTool: Cobertura

--- a/build/invokeDotnetTest.ps1
+++ b/build/invokeDotnetTest.ps1
@@ -1,72 +1,77 @@
-# Copyright (c) 2022-2023 Matthias Wolf, Mawosoft.
+# Copyright (c) 2022-2024 Matthias Wolf, Mawosoft.
 
-# Run dotnet test for projects * configs * frameworks
+<#
+.SYNOPSIS
+    Run dotnet test for projects * configs * frameworks.
+#>
+
+#Requires -Version 7.4
 
 Param (
     [Parameter(Mandatory)]
-    [Alias("p")]
+    [Alias('p')]
     [string[]]$Projects,
 
-    [ValidateSet("Debug", "Release")]
-    [Alias("c")]
-    [string[]]$Configs = @("Debug", "Release"),
+    [ValidateSet('Debug', 'Release')]
+    [Alias('c')]
+    [string[]]$Configs = @('Debug', 'Release'),
 
     [Parameter(Mandatory)]
     # Subset of Microsoft.NET.SupportedTargetFrameworks.props
-    [ValidateSet("net461", "net462", "net472", "net48", "netstandard2.0", "netcoreapp3.1", "net5.0", "net6.0", "net7.0")]
-    [Alias("f")]
+    [ValidateSet('net461', 'net462', 'net472', 'net48', 'netstandard2.0', 'netcoreapp3.1', 'net5.0', 'net6.0', 'net7.0', 'net8.0', 'net9.0')]
+    [Alias('f')]
     [string[]]$Frameworks,
 
-    [ValidateSet("quiet", "minimal", "normal", "detailed")]
-    [Alias("v")]
-    [string]$Verbosity = "minimal",
+    [ValidateSet('quiet', 'minimal', 'normal', 'detailed')]
+    [Alias('v')]
+    [string]$Verbosity = 'minimal',
 
-    [Alias("b")]
+    [Alias('b')]
     # Doesn't add --no-build to dotnet test args
     [switch]$Build,
 
-    [Alias("ff")]
+    [Alias('ff')]
     # Stop after first failing test
     [switch]$FailFast,
 
-    [Alias("r")]
+    [Alias('r')]
     # Defaults to ./TestResults
     [string]$ResultsDirectory,
 
-    [Alias("cc")]
+    [Alias('cc')]
     [switch]$CodeCoverage,
 
-    [Alias("s")]
+    [Alias('s')]
     # If provided, turns on -cc automatically
     [string]$Settings,
 
-    [Alias("a")]
-    # Any additional dotnet test args. Caller must provide proper quoting if needed.
+    [Alias('a')]
+    # Any additional dotnet test args.
     [string[]]$AdditionalArguments
 )
 
-. "$PSScriptRoot/startNativeExecution.ps1"
-
-Set-StrictMode -Version Latest
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
 
 [int]$matrixCount = $Projects.Count * $Configs.Count * $Frameworks.Count
 [int]$failedTestCount = 0
 
 # Init CI log grouping if available
 [string]$groupPrefix = [System.Environment]::NewLine
-[string]$groupSuffix = ""
+[string]$groupSuffix = ''
 
 if ($env:GITHUB_ACTIONS -and $matrixCount -gt 1) {
-    $groupPrefix = "::group::"
-    $groupSuffix = "::endgroup::"
+    $groupPrefix = '::group::'
+    $groupSuffix = '::endgroup::'
 }
 elseif ($env:TF_BUILD -and $matrixCount -gt 1) {
-    $groupPrefix = "##[group]"
-    $groupSuffix = "##[endgroup]"
+    $groupPrefix = '##[group]'
+    $groupSuffix = '##[endgroup]'
 }
 
-if ($ResultsDirectory -eq "") {
-    $ResultsDirectory = Join-Path "." "TestResults"
+if ($ResultsDirectory -eq '') {
+    $ResultsDirectory = Join-Path '.' 'TestResults'
 }
 
 # Run test matrix
@@ -84,40 +89,37 @@ foreach ($project in $Projects) {
             [string]$currentResultsDirectory = Join-Path $projectResultsDirectory $config $framework
 
             # Clear result directory
-            Remove-Item (Join-Path $currentResultsDirectory "*") -Recurse -ErrorAction Ignore
+            Remove-Item (Join-Path $currentResultsDirectory '*') -Recurse -ErrorAction Ignore
 
             # Create dotnet command line
-            [string[]] $params = @("test", "`"$project`"", "--nologo")
+            [string[]] $params = @('test', "$project", '--nologo')
             if (-not $Build.IsPresent) {
-                $params += "--no-build"
+                $params += '--no-build'
             }
             # Dont't use aliases like -r, they could change (-r is now --runtime in SDK >= 7.0)
             # See https://github.com/dotnet/sdk/issues/21952
-            $params += "--configuration", $config
-            $params += "--framework", $framework
-            $params += "--logger", "`"console;verbosity=$Verbosity`""
-            $params += "--results-directory", "`"$currentResultsDirectory`""
-            $params += "--logger", "trx"
-            if ($CodeCoverage.IsPresent -or $Settings -ne "") {
-                $params += "--collect", "`"XPlat Code Coverage`""
-                if ($Settings -ne "") {
-                    $params += "--settings", "`"$Settings`""
+            $params += '--configuration', $config
+            $params += '--framework', $framework
+            $params += '--logger', "console;verbosity=$Verbosity"
+            $params += '--results-directory', $currentResultsDirectory
+            $params += '--logger', 'trx'
+            if ($CodeCoverage.IsPresent -or $Settings -ne '') {
+                $params += '--collect', 'XPlat Code Coverage'
+                if ($Settings -ne '') {
+                    $params += '--settings', $Settings
                 }
             }
-            $params += "--diag", "`"$(Join-Path $currentResultsDirectory "diag.log")`""
+            $params += '--diag', $(Join-Path $currentResultsDirectory 'diag.log')
             if ($AdditionalArguments) {
                 $params += $AdditionalArguments
             }
 
             # Execute and log dotnet test
-            [scriptblock]$scriptblock = { dotnet $params }
-            Write-Host ($groupPrefix + "dotnet") $params -Separator ' '
+            Write-Host ($groupPrefix + 'dotnet') $params -Separator ' '
             [bool]$hasTestErrors = $false
             try {
-                Start-NativeExecution $scriptblock -IgnoreExitcode
-                if ($LASTEXITCODE -ne 0) {
-                    $hasTestErrors = $true
-                }
+                dotnet $params
+                if ($LASTEXITCODE -ne 0) { $hasTestErrors = $true }
             }
             catch {
                 $hasTestErrors = $true
@@ -126,18 +128,18 @@ foreach ($project in $Projects) {
             if ($hasTestErrors) {
                 $failedTestCount++
                 if ($FailFast.IsPresent) {
-                    throw "Test completed with failures and -FailFast was specified."
+                    throw 'Test completed with failures and -FailFast was specified.'
                 }
                 if ($matrixCount -gt 1) {
-                    Write-Warning "Test completed with failures."
+                    Write-Warning 'Test completed with failures.'
                 }
             }
 
             # Copy coverage results (if any) from random subdir into results dir, then remove subdirs
             # Directory may not exist if the test didn't run
             if ([System.IO.Directory]::Exists($currentResultsDirectory)) {
-                Get-ChildItem (Join-Path $currentResultsDirectory "*" "*") -File |
-                Copy-Item -Destination $currentResultsDirectory
+                Get-ChildItem (Join-Path $currentResultsDirectory '*' '*') -File |
+                    Copy-Item -Destination $currentResultsDirectory
                 Get-ChildItem $currentResultsDirectory -Directory | Remove-Item -Recurse
             }
         }
@@ -145,5 +147,5 @@ foreach ($project in $Projects) {
 }
 
 if ($failedTestCount -gt 0) {
-    throw "Some tests were not successful."
+    throw 'Some tests were not successful.'
 }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -56,7 +56,7 @@
         "dest": "_site",
         "globalMetadata": {
             "_appTitle": "Mawosoft Extensions for BenchmarkDotNet",
-            "_appFooter": "Copyright &copy; 2021-2023 Matthias Wolf, Mawosoft",
+            "_appFooter": "Copyright &copy; 2021-2024 Matthias Wolf, Mawosoft",
             "_enableSearch": true,
             "_enableNewTab": true,
             // Templates changed to affect contribution only, but not "view source".

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.401",
+    "version": "8.0.202",
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.0"
+    "Microsoft.Build.NoTargets": "3.7.56"
   }
 }

--- a/samples/ColumnDisplaySamples/GlobalUsings.cs
+++ b/samples/ColumnDisplaySamples/GlobalUsings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 global using System;
 global using System.Collections.Generic;

--- a/samples/ColumnDisplaySamples/JobColumnSample.cs
+++ b/samples/ColumnDisplaySamples/JobColumnSample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/ColumnDisplaySamples/LogParser.cs
+++ b/samples/ColumnDisplaySamples/LogParser.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/ColumnDisplaySamples/LogParser.cs
+++ b/samples/ColumnDisplaySamples/LogParser.cs
@@ -9,25 +9,25 @@ internal static class LogParser
     public static readonly LogCapture LogCapture = new();
     public sealed class SummaryParts
     {
-        public List<OutputLine> Environment = new();
-        public List<OutputLine> Host = new(); // [Host] part of all runtimes
-        public List<OutputLine> Runtimes = new();
-        public List<OutputLine> CommonValues = new();
-        public List<OutputLine> Table = new();
-        public List<OutputLine> Errors = new();
-        public List<OutputLine> Warnings = new();
-        public List<OutputLine> Hints = new();
-        public List<OutputLine> Legend = new();
-        public List<OutputLine> Diagnosers = new();
+        public List<OutputLine> Environment = [];
+        public List<OutputLine> Host = []; // [Host] part of all runtimes
+        public List<OutputLine> Runtimes = [];
+        public List<OutputLine> CommonValues = [];
+        public List<OutputLine> Table = [];
+        public List<OutputLine> Errors = [];
+        public List<OutputLine> Warnings = [];
+        public List<OutputLine> Hints = [];
+        public List<OutputLine> Legend = [];
+        public List<OutputLine> Diagnosers = [];
     }
 
     [SuppressMessage("Performance", "CA1851:Possible multiple enumerations of 'IEnumerable' collection",
         Justification = "Mostly false positive. Ienumerable result gets reassigned after partial enumeration.")]
     public static List<SummaryParts> GetSummaries()
     {
-        List<SummaryParts> summaries = new();
+        List<SummaryParts> summaries = [];
         OutputLine emptyLine = new() { Kind = LogKind.Default, Text = Environment.NewLine };
-        IEnumerable<OutputLine> captured = LogCapture.CapturedOutput.ToList();
+        IEnumerable<OutputLine> captured = [.. LogCapture.CapturedOutput];
         // Using the original IReadOnlyList<> and an index would be more efficient, but Skip/Take
         // is more readable and there aren't really any performance here issues to worry about.
         while (captured.Any())

--- a/samples/ColumnDisplaySamples/ParamColumnSample.cs
+++ b/samples/ColumnDisplaySamples/ParamColumnSample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/ColumnDisplaySamples/ParamWrapperSample.cs
+++ b/samples/ColumnDisplaySamples/ParamWrapperSample.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/ColumnDisplaySamples/Program.cs
+++ b/samples/ColumnDisplaySamples/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/ColumnDisplaySamples/Program.cs
+++ b/samples/ColumnDisplaySamples/Program.cs
@@ -9,7 +9,7 @@ internal sealed class Program
         // Normally, we would just use
         //      BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
         // but that will sort types alphabetically and we want to maintain a certain order.
-        BenchmarkSwitcher switcher = BenchmarkSwitcher.FromTypes(new[] {
+        BenchmarkSwitcher switcher = BenchmarkSwitcher.FromTypes([
             typeof(JobColumnSample1_RunModes_BDNDefault),
             typeof(JobColumnSample1_RunModes_JobColumnSelectionProvider),
             typeof(JobColumnSample2_Runtimes_BDNDefault),
@@ -20,7 +20,7 @@ internal sealed class Program
             typeof(ParamColumnSample_RecyclableParamsColumnProvider_Default),
             typeof(ParamColumnSample_RecyclableParamsColumnProvider_Custom),
             typeof(ParamWrapperSample),
-        });
+        ]);
 
         // All samples use an exclusive local config (ConfigUnionRule.AlwaysUseLocal).
         // You can still specify filters on the command line, but all other options won't have any effect.

--- a/samples/ColumnDisplaySamples/SampleBase.cs
+++ b/samples/ColumnDisplaySamples/SampleBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace ColumnDisplaySamples;
 

--- a/samples/WhatifFilterSample/Program.cs
+++ b/samples/WhatifFilterSample/Program.cs
@@ -48,6 +48,8 @@ public class Benchmarks3
 
 internal sealed class Program
 {
+    private static readonly char[] separator = [' '];
+
     public static void Main(string[] args)
     {
         bool runAllPredefinedSamples = false;
@@ -60,7 +62,7 @@ internal sealed class Program
         {
             runAllPredefinedSamples = true;
             sampleCmdLine = "--runtimes net7.0 net6.0 net48 --whatif";
-            args = sampleCmdLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            args = sampleCmdLine.Split(separator, StringSplitOptions.RemoveEmptyEntries);
         }
 
         // Create the WhatifFilter and let it process the --whatif (or -w for short) argument if one exists.
@@ -108,14 +110,14 @@ internal sealed class Program
             logger.WriteLine();
             logger.WriteLineInfo("Console arguments: " + sampleCmdLine);
             logger.WriteLine();
-            args = sampleCmdLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            args = sampleCmdLine.Split(separator, StringSplitOptions.RemoveEmptyEntries);
             _ = BenchmarkRunner.Run(typeof(Program).Assembly, config, args);
 
             sampleCmdLine = "--runtimes net7.0 net6.0 net48 --list tree";
             logger.WriteLine();
             logger.WriteLineInfo("Console arguments: " + sampleCmdLine);
             logger.WriteLine();
-            args = sampleCmdLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            args = sampleCmdLine.Split(separator, StringSplitOptions.RemoveEmptyEntries);
             _ = BenchmarkRunner.Run(typeof(Program).Assembly, config, args);
 
         }

--- a/samples/WhatifFilterSample/Program.cs
+++ b/samples/WhatifFilterSample/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 using System;
 using BenchmarkDotNet.Attributes;

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/.globalconfig
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/.globalconfig
@@ -11,3 +11,6 @@ dotnet_diagnostic.CA1308.severity = none
 
 # CA1815: Override equals and operator equals on value types
 dotnet_code_quality.CA1815.api_surface = public
+
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = silent

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/ExecuteResultWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/ExecuteResultWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.ApiCompat;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/ExecuteResultWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/ExecuteResultWrapper.cs
@@ -8,13 +8,12 @@ internal static class ExecuteResultWrapper
         typeof(ExecuteResult).GetConstructor(
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
             null,
-            new Type[]
-            {
+            [
                 typeof(List<Measurement>),
                 typeof(GcStats),
                 typeof(ThreadingStats),
                 typeof(double)
-            },
+            ],
             null);
 
     public static ExecuteResult Create(
@@ -25,7 +24,7 @@ internal static class ExecuteResultWrapper
     {
         return s_ctorInternalStable is not null
             ? (ExecuteResult)s_ctorInternalStable.Invoke(
-                new object[] { measurements.ToList(), gcStats, threadingStats, exceptionFrequency })
+                [measurements.ToList(), gcStats, threadingStats, exceptionFrequency])
             : throw new MissingMethodException(nameof(ExecuteResult), ".ctor");
     }
 }

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/GenerateResultWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/GenerateResultWrapper.cs
@@ -14,5 +14,5 @@ internal static class GenerateResultWrapper
     }
 
     public static GenerateResult Success()
-        => Create(ArtifactsPaths.Empty, true, null, Array.Empty<string>());
+        => Create(ArtifactsPaths.Empty, true, null, []);
 }

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/GenerateResultWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/GenerateResultWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.ApiCompat;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/SummaryWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ApiCompat/SummaryWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.ApiCompat;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/BenchmarkRunInfos.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/BenchmarkRunInfos.cs
@@ -14,7 +14,7 @@ public class BenchmarkRunInfos
     public static readonly Job FastInProcessJob =
         new Job("FastInProc", Job.Dry.WithToolchain(InProcessEmitToolchain.Instance)).Freeze();
 
-    private readonly List<BenchmarkRunInfo> _items = new();
+    private readonly List<BenchmarkRunInfo> _items = [];
 
     /// <summary>
     /// Gets or sets the global config to use for subsequent benchmark conversions.
@@ -151,7 +151,7 @@ public class BenchmarkRunInfos
     /// <summary>
     /// Runs all converted benchmarks and returns the results.
     /// </summary>
-    public Summary[] RunAll() => BenchmarkRunner.Run(_items.ToArray());
+    public Summary[] RunAll() => BenchmarkRunner.Run([.. _items]);
 
     private WhatifFilter? PreProcessConverter()
     {
@@ -184,12 +184,12 @@ public class BenchmarkRunInfos
         else
         {
             // We keep the hashset here in case we want to go back to support multiple override jobs.
-            HashSet<Job> jobs = new() { OverrideJob };
+            HashSet<Job> jobs = [OverrideJob];
             foreach (BenchmarkRunInfo runInfo in runInfos)
             {
                 HashSet<BenchmarkCase> oldBenchmarkCases =
                     new(runInfo.BenchmarksCases, BenchmarkCaseWithoutJobEqualityComparer.Instance);
-                List<BenchmarkCase> newBenchmarkCases = new();
+                List<BenchmarkCase> newBenchmarkCases = [];
                 foreach (BenchmarkCase benchmarkCase in oldBenchmarkCases)
                 {
                     foreach (Job job in jobs)
@@ -205,13 +205,13 @@ public class BenchmarkRunInfos
                 }
                 if (newBenchmarkCases.Count > 0)
                 {
-                    _items.Add(new BenchmarkRunInfo(newBenchmarkCases.ToArray(), runInfo.Type, runInfo.Config));
+                    _items.Add(new BenchmarkRunInfo([.. newBenchmarkCases], runInfo.Type, runInfo.Config));
                 }
             }
         }
     }
 
-    private class BenchmarkCaseWithoutJobEqualityComparer : IEqualityComparer<BenchmarkCase>
+    private sealed class BenchmarkCaseWithoutJobEqualityComparer : IEqualityComparer<BenchmarkCase>
     {
         public static readonly BenchmarkCaseWithoutJobEqualityComparer Instance = new();
         public bool Equals(BenchmarkCase x, BenchmarkCase y)

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/BenchmarkRunInfos.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/BenchmarkRunInfos.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ColumnCategoryExtensions.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ColumnCategoryExtensions.cs
@@ -35,7 +35,7 @@ internal static class ColumnCategoryExtensions
 
     // Map known ColumnProviders to ExtendedColumnCategory
     private static readonly Lazy<(Type type, ExtendedColumnCategory category)[]> s_knownColumnProviders
-        = new(() => new[] {
+        = new(() => [
             (DefaultColumnProviders.Descriptor.GetType(), ExtendedColumnCategory.TargetMethod),
             (DefaultColumnProviders.Job.GetType(), ExtendedColumnCategory.Job),
             (DefaultColumnProviders.Statistics.GetType(), ExtendedColumnCategory.Statistics),
@@ -43,7 +43,7 @@ internal static class ColumnCategoryExtensions
             (DefaultColumnProviders.Metrics.GetType(), ExtendedColumnCategory.Metric),
             (typeof(RecyclableParamsColumnProvider), ExtendedColumnCategory.Params),
             (typeof(JobColumnSelectionProvider), ExtendedColumnCategory.Job),
-        });
+        ]);
 
     // Get ExtendedColumnCategory(s) either from mapping or by querying for columns
     public static IEnumerable<ExtendedColumnCategory> GetExtendedColumnCategories(this IColumnProvider columnProvider)
@@ -53,13 +53,13 @@ internal static class ColumnCategoryExtensions
             s_knownColumnProviders.Value.FirstOrDefault(item => item.type == providerType);
         if (providerType == type)
         {
-            return new[] { category };
+            return [category];
         }
         return columnProvider.GetDefaultColumns().Select(c => c.GetExtendedColumnCategory()).Distinct();
     }
 
     // Needed for mock Summary
-    private class MockMetricDescriptor : IMetricDescriptor
+    private sealed class MockMetricDescriptor : IMetricDescriptor
     {
         public string Id => nameof(MockMetricDescriptor);
         public string DisplayName => Id;
@@ -78,21 +78,21 @@ internal static class ColumnCategoryExtensions
         BenchmarkCase benchmarkCase = BenchmarkCase.Create(
             new Descriptor(
                 type: typeof(ConfigExtensions), workloadMethod: (MethodBase.GetCurrentMethod() as MethodInfo)!,
-                baseline: true, categories: new[] { "c1" }
+                baseline: true, categories: ["c1"]
                 ),
             Job.Dry,
-            new ParameterInstances(new[] { new ParameterInstance(
-                new ParameterDefinition("p1", false, new object[] { 1 }, true, typeof(int), 0),
-                1, SummaryStyle.Default) }),
+            new ParameterInstances([ new ParameterInstance(
+                new ParameterDefinition("p1", false, [1], true, typeof(int), 0),
+                1, SummaryStyle.Default) ]),
             DefaultConfig.Instance.CreateImmutableConfig()
             );
         GenerateResult generateResult = GenerateResultWrapper.Success();
         BuildResult buildResult = BuildResult.Success(generateResult);
-        Measurement[] allMeasurements = new[] {
+        Measurement[] allMeasurements = [
             new Measurement(1, IterationMode.Workload, IterationStage.Result, 1, 1, 1)
-        };
-        ExecuteResult[] executeResults = new[] { ExecuteResultWrapper.Create(allMeasurements, default, default, default) };
-        Metric[] metrics = new[] { new Metric(new MockMetricDescriptor(), 1) };
+        ];
+        ExecuteResult[] executeResults = [ExecuteResultWrapper.Create(allMeasurements, default, default, default)];
+        Metric[] metrics = [new Metric(new MockMetricDescriptor(), 1)];
         BenchmarkReport benchmarkReport = new(true, benchmarkCase, generateResult, buildResult, executeResults, metrics);
         return SummaryWrapper.Create(
             string.Empty, ImmutableArray.Create(benchmarkReport), HostEnvironmentInfo.GetCurrent(),

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ColumnCategoryExtensions.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ColumnCategoryExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/CombinedParamsColumn.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/CombinedParamsColumn.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ConfigExtensions.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ConfigExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+﻿// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/GlobalUsings.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/GlobalUsings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 global using System;
 global using System.Collections.Generic;

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/JobCharacteristicColumnWithLegend.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/JobCharacteristicColumnWithLegend.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 
 /// <summary>
 /// Internal class used by <see cref="JobColumnSelectionProvider"/>
 /// </summary>
-internal class JobCharacteristicColumnWithLegend : IColumn
+internal sealed class JobCharacteristicColumnWithLegend : IColumn
 {
     private readonly IColumn _inner;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/JobCharacteristicColumnWithLegend.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/JobCharacteristicColumnWithLegend.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/JobColumnSelectionProvider.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/JobColumnSelectionProvider.cs
@@ -130,7 +130,8 @@ public class JobColumnSelectionProvider : IColumnProvider
         }
     }
 
-    private class FilterFactory
+    [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "False positive.")]
+    private sealed class FilterFactory
     {
         private readonly (Characteristic characteristic, IColumn? column)[] _allCharacteristicsAndColumns;
         private readonly Dictionary<string, (int index, int[] childIndices)> _idToIndexLookup;
@@ -173,7 +174,7 @@ public class JobColumnSelectionProvider : IColumnProvider
         {
             if (filterExpression is null)
                 throw new ArgumentNullException(nameof(filterExpression));
-            string[] filterExpressions = filterExpression.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] filterExpressions = filterExpression.Split([' '], StringSplitOptions.RemoveEmptyEntries);
             CharacteristicFilter[] retVal =
                 _allCharacteristicsAndColumns.Select(i => new CharacteristicFilter(i.characteristic, i.column)).ToArray();
             for (int i = 0; i < filterExpressions.Length; i++)

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/JobColumnSelectionProvider.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/JobColumnSelectionProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/Mawosoft.Extensions.BenchmarkDotNet.csproj
@@ -19,7 +19,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <PackageReleaseNotes>This release supports BenchmarkDotNet 0.13.8 and BDN nightly builds up to at least 0.13.9-nightly.20230922.72</PackageReleaseNotes>
+    <PackageReleaseNotes>This release supports BenchmarkDotNet 0.13.8 and BDN nightly builds up to at least 0.13.13-nightly.20240310.144</PackageReleaseNotes>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>0.2.1</PackageValidationBaselineVersion>
   </PropertyGroup>

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/ParamWrapper.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/ParamWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamColumn.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamColumn.cs
@@ -5,7 +5,7 @@ namespace Mawosoft.Extensions.BenchmarkDotNet;
 /// <summary>
 /// Internal class used by <see cref="RecyclableParamsColumnProvider"/>
 /// </summary>
-internal class RecyclableParamColumn : IColumn
+internal sealed class RecyclableParamColumn : IColumn
 {
     [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression",
         Justification = "False warning for IDE0032 supression.")]

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamColumn.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamColumn.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamsColumnProvider.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamsColumnProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 
@@ -25,7 +25,7 @@ public class RecyclableParamsColumnProvider : IColumnProvider
     {
         if (summary is null || summary.BenchmarksCases.Length == 0)
         {
-            return Array.Empty<IColumn>();
+            return [];
         }
         int maxParamCount = summary.BenchmarksCases.Max(b => b.Parameters.Count);
         List<IColumn> columns = new(maxParamCount);

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamsColumnProvider.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/RecyclableParamsColumnProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/src/Mawosoft.Extensions.BenchmarkDotNet/WhatifFilter.cs
+++ b/src/Mawosoft.Extensions.BenchmarkDotNet/WhatifFilter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet;
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/.globalconfig
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/.globalconfig
@@ -9,6 +9,12 @@ dotnet_diagnostic.CA1307.severity = none
 # CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = none
 
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
+
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = none
+
 # Common settings for test projects
 
 # CA1034: Nested types should not be visible

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/BDNVersionTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/BDNVersionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/BDNVersionTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/BDNVersionTests.cs
@@ -30,7 +30,7 @@ public class BDNVersionTests
     [Fact]
     public void BDNAssemblyGetTypes()
     {
-        List<Type> types = new();
+        List<Type> types = [];
         Assembly assembly = typeof(BenchmarkCase).Assembly;
         try
         {

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 #if BDN_NIGHTLY
 using Perfolizer.Metrology;

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
@@ -6,9 +6,9 @@ namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
 
 public class ColumnCategoryExtensionsTests
 {
-    private static IEnumerable<Type> GetTypesWrapper(Assembly assembly)
+    private static List<Type> GetTypesWrapper(Assembly assembly)
     {
-        List<Type> types = new();
+        List<Type> types = [];
         try
         {
             types.AddRange(assembly.GetTypes());
@@ -74,7 +74,7 @@ public class ColumnCategoryExtensionsTests
                 .Concat(typeof(ColumnCategoryExtensions).Assembly.GetTypes().Where(predicate)
                 .Distinct());
 
-            List<string> unexpectedTypes = new();
+            List<string> unexpectedTypes = [];
 
             foreach (Type type in columnTypes)
             {
@@ -168,7 +168,7 @@ public class ColumnCategoryExtensionsTests
                 .Concat(typeof(ColumnCategoryExtensions).Assembly.GetTypes().Where(predicate)
                 .Distinct());
 
-            List<string> unexpectedTypes = new();
+            List<string> unexpectedTypes = [];
 
             foreach (Type type in providerTypes)
             {
@@ -178,42 +178,42 @@ public class ColumnCategoryExtensionsTests
                     case "CompositeColumnProvider":
                         Add(new CompositeColumnProvider(
                                 DefaultColumnProviders.Descriptor, DefaultColumnProviders.Job),
-                            new[] { ExtendedColumnCategory.TargetMethod, ExtendedColumnCategory.Job });
+                            [ExtendedColumnCategory.TargetMethod, ExtendedColumnCategory.Job]);
                         Add(new CompositeColumnProvider(
                                 new JobColumnSelectionProvider("-all +job", true), new RecyclableParamsColumnProvider()),
-                            new[] { ExtendedColumnCategory.Job, ExtendedColumnCategory.Params });
+                            [ExtendedColumnCategory.Job, ExtendedColumnCategory.Params]);
                         break;
                     case "EmptyColumnProvider":
-                        Add(EmptyColumnProvider.Instance, Array.Empty<ExtendedColumnCategory>());
+                        Add(EmptyColumnProvider.Instance, []);
                         break;
                     case "SimpleColumnProvider":
                         Add(new SimpleColumnProvider(
                                 StatisticColumn.Mean, StatisticColumn.Error, TargetMethodColumn.Method),
-                            new[] { ExtendedColumnCategory.Statistics, ExtendedColumnCategory.TargetMethod });
+                            [ExtendedColumnCategory.Statistics, ExtendedColumnCategory.TargetMethod]);
                         Add(new SimpleColumnProvider(new CategoriesColumn()),
-                            new[] { ExtendedColumnCategory.Category });
+                            [ExtendedColumnCategory.Category]);
                         break;
                     case "DescriptorColumnProvider":
-                        Add(DefaultColumnProviders.Descriptor, new[] { ExtendedColumnCategory.TargetMethod });
+                        Add(DefaultColumnProviders.Descriptor, [ExtendedColumnCategory.TargetMethod]);
                         break;
                     case "JobColumnProvider":
-                        Add(DefaultColumnProviders.Job, new[] { ExtendedColumnCategory.Job });
+                        Add(DefaultColumnProviders.Job, [ExtendedColumnCategory.Job]);
                         break;
                     case "StatisticsColumnProvider":
-                        Add(DefaultColumnProviders.Statistics, new[] { ExtendedColumnCategory.Statistics });
+                        Add(DefaultColumnProviders.Statistics, [ExtendedColumnCategory.Statistics]);
                         break;
                     case "ParamsColumnProvider":
-                        Add(DefaultColumnProviders.Params, new[] { ExtendedColumnCategory.Params });
+                        Add(DefaultColumnProviders.Params, [ExtendedColumnCategory.Params]);
                         break;
                     case "MetricsColumnProvider":
-                        Add(DefaultColumnProviders.Metrics, new[] { ExtendedColumnCategory.Metric });
+                        Add(DefaultColumnProviders.Metrics, [ExtendedColumnCategory.Metric]);
                         break;
                     // Mawosoft.Extensions.BenchmarkDotNet
                     case "JobColumnSelectionProvider":
-                        Add(new JobColumnSelectionProvider("+all", true), new[] { ExtendedColumnCategory.Job });
+                        Add(new JobColumnSelectionProvider("+all", true), [ExtendedColumnCategory.Job]);
                         break;
                     case "RecyclableParamsColumnProvider":
-                        Add(new RecyclableParamsColumnProvider(), new[] { ExtendedColumnCategory.Params });
+                        Add(new RecyclableParamsColumnProvider(), [ExtendedColumnCategory.Params]);
                         break;
                     default:
                         unexpectedTypes.Add(type.Name);

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ColumnCategoryExtensionsTests.cs
@@ -1,5 +1,11 @@
 // Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
 
+#if BDN_NIGHTLY
+using Perfolizer.Metrology;
+#else
+using Perfolizer.Mathematics.SignificanceTesting;
+using Perfolizer.Mathematics.Thresholds;
+#endif
 using static Mawosoft.Extensions.BenchmarkDotNet.ColumnCategoryExtensions;
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
@@ -57,7 +63,11 @@ public class ColumnCategoryExtensionsTests
             public string Legend => nameof(MockMetricDescriptor);
             public string NumberFormat => "0.##";
             public UnitType UnitType => UnitType.Size;
+#if BDN_NIGHTLY
+            public string Unit => SizeUnit.B.Abbreviation;
+#else
             public string Unit => SizeUnit.B.Name;
+#endif
             public bool TheGreaterTheBetter => false;
             public int PriorityInCategory => 0;
             public bool GetIsAvailable(Metric metric) => true;
@@ -111,7 +121,11 @@ public class ColumnCategoryExtensionsTests
                         Add(RankColumn.Arabic, ExtendedColumnCategory.Custom);
                         break;
                     case "StatisticalTestColumn":
-                        Add(new StatisticalTestColumn(Perfolizer.Mathematics.SignificanceTesting.StatisticalTestKind.Welch, Perfolizer.Mathematics.Thresholds.Threshold.Create(Perfolizer.Mathematics.Thresholds.ThresholdUnit.Ratio, 0), true), ExtendedColumnCategory.Baseline);
+#if BDN_NIGHTLY
+                        Add(new StatisticalTestColumn(new Threshold()), ExtendedColumnCategory.Baseline);
+#else
+                        Add(new StatisticalTestColumn(StatisticalTestKind.Welch, Threshold.Create(ThresholdUnit.Ratio, 0), true), ExtendedColumnCategory.Baseline);
+#endif
                         break;
                     case "StatisticColumn":
                         Add(StatisticColumn.Mean, ExtendedColumnCategory.Statistics);

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.Columns.cs
@@ -6,8 +6,8 @@ public partial class ConfigExtensionsTests
 {
     private static void AssertColumnsEqual(IConfig expected, IConfig actual)
     {
-        List<Type> expectedResult = new();
-        List<Type> actualResult = new();
+        List<Type> expectedResult = [];
+        List<Type> actualResult = [];
         Flatten(expected.GetColumnProviders(), expectedResult);
         Flatten(actual.GetColumnProviders(), actualResult);
         Assert.Equal(expectedResult, actualResult);
@@ -45,25 +45,23 @@ public partial class ConfigExtensionsTests
     {
         public ReplaceColumnCategory_WithColumns_TheoryData()
         {
-            Add(new IColumnProvider[]
-                {
+            Add(
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     DefaultColumnProviders.Statistics,
                     DefaultColumnProviders.Params,
                     DefaultColumnProviders.Metrics
-                },
-                new IColumn[]
-                {
+                ],
+                [
                     StatisticColumn.Mean,
                     new CombinedParamsColumn()
-                },
-                new IColumnProvider[]
-                {
+                ],
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     DefaultColumnProviders.Metrics
-                });
+                ]);
         }
     }
 
@@ -86,25 +84,23 @@ public partial class ConfigExtensionsTests
     {
         public ReplaceColumnCategory_WithProviders_TheoryData()
         {
-            Add(new IColumnProvider[]
-                {
+            Add(
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     DefaultColumnProviders.Statistics,
                     DefaultColumnProviders.Params,
                     DefaultColumnProviders.Metrics
-                },
-                new IColumnProvider[]
-                {
+                ],
+                [
                     new JobColumnSelectionProvider("-all +job"),
                     new RecyclableParamsColumnProvider()
-                },
-                new IColumnProvider[]
-                {
+                ],
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Statistics,
                     DefaultColumnProviders.Metrics
-                });
+                ]);
         }
     }
 
@@ -127,23 +123,22 @@ public partial class ConfigExtensionsTests
     {
         public RemoveColumnsByCategory_TheoryData()
         {
-            Add(new IColumnProvider[]
-                {
+            Add(
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     DefaultColumnProviders.Statistics,
                     DefaultColumnProviders.Params,
                     DefaultColumnProviders.Metrics
-                },
-                new ColumnCategory[] { ColumnCategory.Job, ColumnCategory.Statistics },
-                new IColumnProvider[]
-                {
+                ],
+                [ColumnCategory.Job, ColumnCategory.Statistics],
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Params,
                     DefaultColumnProviders.Metrics
-                });
-            Add(new IColumnProvider[]
-                {
+                ]);
+            Add(
+                [
                     new CompositeColumnProvider
                     (
                         DefaultColumnProviders.Descriptor,
@@ -158,10 +153,9 @@ public partial class ConfigExtensionsTests
                         DefaultColumnProviders.Params,
                         DefaultColumnProviders.Metrics
                     )
-                },
-                new ColumnCategory[] { ColumnCategory.Statistics, ColumnCategory.Params },
-                new IColumnProvider[]
-                {
+                ],
+                [ColumnCategory.Statistics, ColumnCategory.Params],
+                [
                     new CompositeColumnProvider
                     (
                         DefaultColumnProviders.Descriptor,
@@ -172,9 +166,9 @@ public partial class ConfigExtensionsTests
                         ),
                         DefaultColumnProviders.Metrics
                     )
-                });
-            Add(new IColumnProvider[]
-                {
+                ]);
+            Add(
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     new CompositeColumnProvider
@@ -188,14 +182,13 @@ public partial class ConfigExtensionsTests
                         new ParamColumn("param")
                     ),
                     DefaultColumnProviders.Metrics
-                },
-                new ColumnCategory[] { ColumnCategory.Statistics, ColumnCategory.Params },
-                new IColumnProvider[]
-                {
+                ],
+                [ColumnCategory.Statistics, ColumnCategory.Params],
+                [
                     DefaultColumnProviders.Descriptor,
                     DefaultColumnProviders.Job,
                     DefaultColumnProviders.Metrics
-                });
+                ]);
         }
     }
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
@@ -54,9 +54,9 @@ public partial class ConfigExtensionsTests
         foreach ((Type item, MethodInfo add, MethodInfo get) in s_methodPairs.Value)
         {
             if (item == itemTypeToExclude) continue;
-            object? retVal = get.Invoke(source, Array.Empty<object?>());
-            retVal = genericToArray.MakeGenericMethod(item).Invoke(null, new object?[] { retVal });
-            add.Invoke(config, new object?[] { retVal });
+            object? retVal = get.Invoke(source, []);
+            retVal = genericToArray.MakeGenericMethod(item).Invoke(null, [retVal]);
+            add.Invoke(config, [retVal]);
         }
         // Statements in IConfig order
         //config.ConfigAnalysisConclusion not settable on ManualConfig
@@ -75,8 +75,8 @@ public partial class ConfigExtensionsTests
     {
         foreach ((_, _, MethodInfo get) in s_methodPairs.Value)
         {
-            object? retLeft = get.Invoke(expected, Array.Empty<object?>());
-            object? retRight = get.Invoke(actual, Array.Empty<object?>());
+            object? retLeft = get.Invoke(expected, []);
+            object? retRight = get.Invoke(actual, []);
             Assert.Equal(retLeft, retRight);
         }
         // Statements in IConfig order

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/ConfigExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/GlobalUsings.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/GlobalUsings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 global using System;
 global using System.Collections;

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/Mawosoft.Extensions.BenchmarkDotNet.Tests.proj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/Mawosoft.Extensions.BenchmarkDotNet.Tests.proj
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;$(NetFxTfm)</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetFxTfm)</TargetFrameworks>
     <RootNamespace>Mawosoft.Extensions.BenchmarkDotNet.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/NightlyBDN/Mawosoft.Extensions.BenchmarkDotNet.Tests.NightlyBDN.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <DefineConstants>$(DefineConstants);BDN_NIGHTLY</DefineConstants>
     <BDNNightlyVersion Condition="'$(BDNNightlyVersion)' == ''">*-*</BDNNightlyVersion>
     <!-- These work with both msbuild console builds and VStudio 2019 builds.
          - RestoreAdditionalProjectSources, RestoreSources
@@ -14,6 +15,13 @@
   <ItemGroup>
     <!-- Already included in ../Directory.Build.props -->
     <PackageReference Update="BenchmarkDotNet" VersionOverride="$(BDNNightlyVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Pinned to resolve MSB3277 conflicts -->
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/WhatifFilterTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/WhatifFilterTests.cs
@@ -75,7 +75,7 @@ public class WhatifFilterTests
     {
         string[]? args = arguments?.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         string[] expected = expectedPreparsed?.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                            ?? (string[]?)args?.Clone() ?? Array.Empty<string>();
+                            ?? (string[]?)args?.Clone() ?? [];
         WhatifFilter whatifFilter = new();
         args = whatifFilter.PreparseConsoleArguments(args!);
         Assert.Equal(expectedEnabled, whatifFilter.Enabled);
@@ -137,21 +137,20 @@ public class WhatifFilterTests
     [Fact]
     public void FilteredBenchmarkCases_EqualsConvertedBenchmarks()
     {
-        Type[] types = new[] { typeof(Benchmarks1), typeof(Benchmarks2), typeof(Benchmarks3) };
+        Type[] types = [typeof(Benchmarks1), typeof(Benchmarks2), typeof(Benchmarks3)];
         WhatifFilter whatifFilter = new();
         ManualConfig config = ManualConfig.CreateEmpty().AddFilter(whatifFilter);
         // Do *NOT* allow deferred execution here, otherwise expected will be empty
-        BenchmarkCase[] expected = types
+        BenchmarkCase[] expected = [.. types
             .SelectMany(t => BenchmarkConverter.TypeToBenchmarks(t, config).BenchmarksCases)
-            .OrderBy(b => b.DisplayInfo)
-            .ToArray();
+            .OrderBy(b => b.DisplayInfo)];
         // Run again with filter enabled
         whatifFilter.Enabled = true;
         Assert.Empty(types.SelectMany(t => BenchmarkConverter.TypeToBenchmarks(t, config).BenchmarksCases));
-        Assert.Equal(expected, whatifFilter.FilteredBenchmarkCases.OrderBy(b => b.DisplayInfo));
-        Assert.Equal(expected,
-                     whatifFilter.FilteredBenchmarkRunInfos.SelectMany(r => r.BenchmarksCases)
-                                                           .OrderBy(b => b.DisplayInfo));
+        BenchmarkCase[] actual1 = [.. whatifFilter.FilteredBenchmarkCases.OrderBy(b => b.DisplayInfo)];
+        Assert.Equal(expected, actual1);
+        BenchmarkCase[] actual2 = [.. whatifFilter.FilteredBenchmarkRunInfos.SelectMany(r => r.BenchmarksCases).OrderBy(b => b.DisplayInfo)];
+        Assert.Equal(expected, actual2);
     }
 
     // TODO More detailed tests
@@ -161,7 +160,7 @@ public class WhatifFilterTests
     public void PrintAsSummaries_Succeeds(bool join)
     {
         AccumulationLogger logger = new(); // This is text-only. Use LogCapture if LogKind is needed.
-        Type[] types = new[] { typeof(Benchmarks1), typeof(Benchmarks2), typeof(Benchmarks3) };
+        Type[] types = [typeof(Benchmarks1), typeof(Benchmarks2), typeof(Benchmarks3)];
         WhatifFilter whatifFilter = new() { Enabled = true };
         ManualConfig config = ManualConfig.Create(DefaultConfig.Instance)
             .ReplaceLoggers(logger)

--- a/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/WhatifFilterTests.cs
+++ b/tests/Mawosoft.Extensions.BenchmarkDotNet.Tests/WhatifFilterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Matthias Wolf, Mawosoft.
+// Copyright (c) 2021-2024 Matthias Wolf, Mawosoft.
 
 namespace Mawosoft.Extensions.BenchmarkDotNet.Tests;
 


### PR DESCRIPTION
* Update CI
  - Adjust for PowerShell 7.4
  - Replace test.ps1 with invokeDotnetTest.ps1 from misc-scripts repo.
  - Use dotnet-file for common external scripts.
  - Closes #322.

* Bump dotnet SDK and package dependencies.
  - Bump dotnet SDK to 8.0.202 and fix resulting analyzer warnings.
  - Update package dependencies. Closes #327.
  - Remove unnecessary transitive pinnings.

* Tolerate breaking changes in BDN >= 0.13.13-nightly.20240310.144
  - Note: Affects only tests, but requires conditional compilation for BDN nightlies.
  - Closes #324.

* Update Copyright year.




